### PR TITLE
chore(model-metadata): refresh the models.dev snapshot

### DIFF
--- a/scripts/model-metadata/models-dev-api.snapshot.json
+++ b/scripts/model-metadata/models-dev-api.snapshot.json
@@ -3,11 +3,11 @@
   "sourceUrl": "https://models.dev/api.json",
   "origin": {
     "kind": "models-dev-response",
-    "retrievedAt": "2026-09-01T10:29:38.000Z",
-    "etag": "W/\"7559b5b3701539769901f1e20e89315d\"",
-    "responseSha256": "7559b5b3701539769901f1e20e89315d94975a7b289646590d6f854a21e12f17"
+    "retrievedAt": "2026-09-12T13:37:26.000Z",
+    "etag": "W/\"07617fe08e8038b5fa2d5018dfe896a7\"",
+    "responseSha256": "07617fe08e8038b5fa2d5018dfe896a7478d6f48f2e78af2bc308d32914c5560"
   },
-  "projectionSha256": "85b25f334b65929079ea6dab9b0a2a66f433e3d66710fcd1aadff5f611b37345",
+  "projectionSha256": "68eb80acc19856d1eaa5c760f6ff3919e48c803ef85cee77e1ae92c563fca9e5",
   "projection": {
     "metadata": {
       "anthropic": {
@@ -25,11 +25,57 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "claude-fable-5-1": {
+          "displayName": "Claude Fable 5.1",
+          "description": "Claude model for demanding reasoning and long-horizon agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-06",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-01",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5": {
@@ -47,8 +93,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5-20251001": {
@@ -66,8 +118,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5": {
@@ -85,11 +143,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5-20251101": {
@@ -107,11 +175,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-6": {
@@ -129,11 +207,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-7": {
@@ -151,11 +240,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-8": {
@@ -173,11 +274,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -195,11 +308,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5": {
@@ -217,8 +342,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5-20250929": {
@@ -236,8 +367,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-6": {
@@ -255,11 +392,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -277,12 +425,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -302,12 +462,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -324,11 +491,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qvq-max": {
@@ -345,8 +524,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-flash": {
@@ -366,8 +550,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-max": {
@@ -384,8 +572,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-plus": {
@@ -402,8 +594,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-turbo": {
@@ -420,8 +616,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-omni-turbo": {
@@ -438,8 +638,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -456,8 +664,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-plus": {
@@ -477,8 +692,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-plus-character-ja": {
@@ -495,8 +714,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-turbo": {
@@ -516,8 +739,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-max": {
@@ -534,8 +761,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-ocr": {
@@ -552,8 +784,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-plus": {
@@ -570,8 +807,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -588,8 +830,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -606,8 +852,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -624,8 +874,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -642,8 +896,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-omni-7b": {
@@ -660,8 +918,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -678,8 +944,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -696,8 +967,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-14b": {
@@ -717,8 +993,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-235b-a22b": {
@@ -738,8 +1018,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-32b": {
@@ -759,8 +1043,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-8b": {
@@ -780,8 +1068,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-asr-flash": {
@@ -798,8 +1090,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -816,8 +1112,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -834,8 +1134,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-flash": {
@@ -852,8 +1156,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -870,8 +1178,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-livetranslate-flash-realtime": {
@@ -888,8 +1200,16 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-max": {
@@ -906,8 +1226,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -924,8 +1248,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -942,8 +1270,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-omni-flash": {
@@ -963,8 +1295,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -981,8 +1321,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -999,8 +1347,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -1017,8 +1370,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-plus": {
@@ -1038,8 +1396,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-122b-a10b": {
@@ -1059,8 +1422,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-27b": {
@@ -1080,8 +1450,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-35b-a3b": {
@@ -1101,8 +1478,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -1122,8 +1506,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -1143,8 +1534,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-27b": {
@@ -1164,8 +1561,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-35b-a3b": {
@@ -1185,8 +1589,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -1206,8 +1617,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-max-preview": {
@@ -1227,8 +1644,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -1248,8 +1669,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -1268,8 +1695,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -1289,8 +1720,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-flash": {
@@ -1307,12 +1744,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -1329,12 +1776,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-plus": {
@@ -1351,8 +1809,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -1370,8 +1832,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-0528": {
@@ -1387,8 +1853,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-llama-70b": {
@@ -1404,8 +1874,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-llama-8b": {
@@ -1422,8 +1896,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-1-5b": {
@@ -1440,8 +1918,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-14b": {
@@ -1457,8 +1939,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-32b": {
@@ -1474,8 +1960,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-r1-distill-qwen-7b": {
@@ -1491,8 +1981,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3": {
@@ -1508,8 +2002,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3-1": {
@@ -1525,8 +2023,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v3-2-exp": {
@@ -1542,8 +2044,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -1561,12 +2067,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -1584,12 +2097,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -1608,8 +2128,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -1629,8 +2153,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -1647,8 +2175,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking": {
@@ -1665,8 +2197,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -1687,8 +2223,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -1709,8 +2251,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi/kimi-k2.5": {
@@ -1731,8 +2279,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -1748,8 +2302,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax/MiniMax-M2.7": {
@@ -1765,8 +2323,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshot-kimi-k2-instruct": {
@@ -1783,8 +2345,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qvq-max": {
@@ -1801,8 +2367,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-deep-research": {
@@ -1819,8 +2390,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-doc-turbo": {
@@ -1837,8 +2412,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-flash": {
@@ -1858,8 +2437,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-long": {
@@ -1876,8 +2459,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-math-plus": {
@@ -1894,8 +2481,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-math-turbo": {
@@ -1912,8 +2503,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-max": {
@@ -1930,8 +2525,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-plus": {
@@ -1948,8 +2547,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-mt-turbo": {
@@ -1966,8 +2569,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-omni-turbo": {
@@ -1984,8 +2591,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -2002,8 +2617,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen-plus": {
@@ -2023,8 +2645,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-plus-character": {
@@ -2041,8 +2667,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-turbo": {
@@ -2062,8 +2692,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-max": {
@@ -2080,8 +2714,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-ocr": {
@@ -2098,8 +2737,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-vl-plus": {
@@ -2116,8 +2760,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -2134,8 +2783,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -2152,8 +2805,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -2170,8 +2827,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -2188,8 +2849,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-coder-32b-instruct": {
@@ -2206,8 +2871,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-coder-7b-instruct": {
@@ -2224,8 +2893,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-math-72b-instruct": {
@@ -2242,8 +2915,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-math-7b-instruct": {
@@ -2260,8 +2937,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-omni-7b": {
@@ -2278,8 +2959,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -2296,8 +2985,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -2314,8 +3008,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-14b": {
@@ -2335,8 +3034,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-235b-a22b": {
@@ -2356,8 +3059,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-32b": {
@@ -2377,8 +3084,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-8b": {
@@ -2398,8 +3109,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-asr-flash": {
@@ -2416,8 +3131,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -2434,8 +3153,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -2452,8 +3175,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-flash": {
@@ -2470,8 +3197,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -2488,8 +3219,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max": {
@@ -2506,8 +3241,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -2524,8 +3263,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -2542,8 +3285,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-omni-flash": {
@@ -2563,8 +3310,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -2581,8 +3336,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -2599,8 +3361,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -2617,8 +3384,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-vl-plus": {
@@ -2638,8 +3410,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -2659,8 +3436,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-flash": {
@@ -2681,8 +3464,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -2702,8 +3491,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -2723,8 +3518,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-max-preview": {
@@ -2744,8 +3545,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -2765,8 +3570,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-flash": {
@@ -2787,8 +3598,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -2807,8 +3624,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -2828,8 +3649,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-flash": {
@@ -2846,12 +3673,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -2868,12 +3705,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-32b": {
@@ -2890,8 +3738,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwq-plus": {
@@ -2908,8 +3760,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-r1-0528": {
@@ -2926,8 +3782,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3-0324": {
@@ -2944,8 +3804,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3.1-terminus": {
@@ -2965,8 +3829,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "siliconflow/deepseek-v3.2": {
@@ -2986,8 +3854,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tongyi-intent-detect-v3": {
@@ -3004,8 +3876,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3028,8 +3904,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3049,8 +3929,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -3071,8 +3955,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3089,8 +3978,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-next": {
@@ -3108,8 +4001,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -3127,8 +4024,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -3146,8 +4047,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -3168,8 +4073,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -3189,8 +4099,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -3211,8 +4127,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -3231,8 +4153,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -3253,8 +4179,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3277,8 +4209,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3298,8 +4234,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -3320,8 +4260,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3339,8 +4285,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-next": {
@@ -3358,8 +4308,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder-plus": {
@@ -3377,8 +4331,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -3396,8 +4354,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -3418,8 +4380,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -3439,8 +4407,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -3461,8 +4435,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -3481,8 +4461,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -3503,8 +4487,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -3528,8 +4518,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -3548,12 +4542,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -3572,12 +4573,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -3596,12 +4604,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -3619,12 +4634,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -3645,8 +4667,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -3667,8 +4693,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -3686,11 +4716,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -3707,8 +4744,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["video"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "happyhorse-1.1-r2v": {
@@ -3725,8 +4767,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["video"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "happyhorse-1.1-t2v": {
@@ -3743,8 +4790,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -3766,8 +4817,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -3789,8 +4846,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -3812,8 +4875,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -3831,8 +4900,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-image-2.0": {
@@ -3849,8 +4922,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen-image-2.0-pro": {
@@ -3867,8 +4944,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -3889,8 +4970,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -3912,8 +4999,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -3934,8 +5027,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -3957,8 +5054,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-flash": {
@@ -3976,12 +5079,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -3999,18 +5112,29 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max-preview": {
           "displayName": "Qwen3.8 Max Preview",
           "description": "Preview Qwen flagship for million-token multimodal reasoning and long-horizon agentic workflows",
-          "lifecycle": "beta",
+          "lifecycle": "deprecated",
           "contextWindow": 1000000,
           "maxOutputTokens": 131072,
           "structuredOutput": true,
@@ -4022,11 +5146,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "wan2.7-image": {
@@ -4043,8 +5177,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "wan2.7-image-pro": {
@@ -4061,8 +5199,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         }
       },
@@ -4086,8 +5228,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -4106,12 +5252,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -4130,12 +5283,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -4154,12 +5314,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -4177,12 +5344,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -4203,8 +5377,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -4225,8 +5403,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -4244,11 +5426,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -4265,8 +5454,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["video"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "happyhorse-1.1-r2v": {
@@ -4283,8 +5477,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["video"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "happyhorse-1.1-t2v": {
@@ -4301,8 +5500,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -4324,8 +5527,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -4347,8 +5556,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -4370,8 +5585,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -4389,8 +5610,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen-image-2.0": {
@@ -4407,8 +5632,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen-image-2.0-pro": {
@@ -4425,8 +5654,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen3.6-flash": {
@@ -4447,8 +5680,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -4470,8 +5709,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -4492,8 +5737,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -4515,8 +5764,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-flash": {
@@ -4534,12 +5789,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -4557,18 +5822,29 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max-preview": {
           "displayName": "Qwen3.8 Max Preview",
           "description": "Preview Qwen flagship for million-token multimodal reasoning and long-horizon agentic workflows",
-          "lifecycle": "beta",
+          "lifecycle": "deprecated",
           "contextWindow": 1000000,
           "maxOutputTokens": 131072,
           "structuredOutput": true,
@@ -4580,11 +5856,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "wan2.7-image": {
@@ -4601,8 +5887,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "wan2.7-image-pro": {
@@ -4619,33 +5909,16 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         }
       },
       "cerebras": {
-        "gemma-4-31b": {
-          "displayName": "Gemma 4 31B IT",
-          "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
-          "lifecycle": "beta",
-          "contextWindow": 131072,
-          "maxOutputTokens": 40960,
-          "structuredOutput": true,
-          "lastUpdated": "2026-07-01",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
         "gpt-oss-120b": {
           "displayName": "GPT OSS 120B",
           "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
@@ -4660,11 +5933,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "qwen-3.8-27b": {
+          "displayName": "Qwen3.8 27B",
+          "description": "Dense 27B vision-language model for coding, agent tasks, and image and video understanding",
+          "lifecycle": "active",
+          "contextWindow": 65536,
+          "maxOutputTokens": 32768,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-03",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -4682,8 +5994,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-expanse-8b": {
@@ -4699,8 +6015,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-vision-32b": {
@@ -4716,8 +6036,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "c4ai-aya-vision-8b": {
@@ -4733,8 +6058,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-03-2025": {
@@ -4751,8 +6081,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-plus-05-2026": {
@@ -4773,8 +6107,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-reasoning-08-2025": {
@@ -4794,8 +6133,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-translate-08-2025": {
@@ -4812,8 +6155,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-a-vision-07-2025": {
@@ -4830,8 +6177,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r-08-2024": {
@@ -4848,8 +6200,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r-plus-08-2024": {
@@ -4866,8 +6222,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r7b-12-2024": {
@@ -4884,8 +6244,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "command-r7b-arabic-02-2025": {
@@ -4902,8 +6266,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "north-mini-code-1-0": {
@@ -4922,11 +6290,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -4945,8 +6320,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
@@ -4964,8 +6343,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-flash-0731": {
@@ -4983,12 +6366,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-pro-0813": {
@@ -5005,12 +6395,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/google/gemma-4-26b-a4b-it": {
@@ -5027,12 +6424,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/ibm-granite/granite-4.0-h-micro": {
@@ -5049,8 +6455,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.1-8b-instruct-fp8": {
@@ -5068,8 +6478,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-11b-vision-instruct": {
@@ -5087,8 +6501,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-1b-instruct": {
@@ -5106,8 +6525,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.2-3b-instruct": {
@@ -5125,8 +6548,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
@@ -5144,8 +6571,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-4-scout-17b-16e-instruct": {
@@ -5163,8 +6594,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/meta/llama-guard-3-8b": {
@@ -5182,8 +6618,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/mistralai/mistral-small-3.1-24b-instruct": {
@@ -5200,8 +6640,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/moonshotai/kimi-k2.6": {
@@ -5219,12 +6663,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/moonshotai/kimi-k2.7-code": {
@@ -5242,12 +6695,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/nvidia/nemotron-3-120b-a12b": {
@@ -5264,12 +6726,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/openai/gpt-oss-120b": {
@@ -5286,11 +6756,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/openai/gpt-oss-20b": {
@@ -5307,8 +6785,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen2.5-coder-32b-instruct": {
@@ -5325,8 +6807,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen3-30b-a3b-fp8": {
@@ -5343,8 +6829,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwen3.8-27b": {
@@ -5361,12 +6851,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/qwen/qwq-32b": {
@@ -5384,8 +6883,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-4.7-flash": {
@@ -5403,12 +6906,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-5.2": {
@@ -5425,12 +6936,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-5.3": {
@@ -5447,12 +6966,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
-            "toggle": true
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "@cf/zai-org/glm-5.3-flash": {
@@ -5469,8 +6995,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -5489,11 +7020,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance/Seed-2.0-mini": {
@@ -5510,8 +7051,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance/Seed-2.0-pro": {
@@ -5528,8 +7074,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -5547,8 +7098,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -5565,8 +7120,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -5583,8 +7142,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -5604,8 +7167,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -5626,8 +7193,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -5645,12 +7216,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -5671,8 +7251,43 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -5690,12 +7305,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -5712,12 +7336,124 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/DeepSeek-V4.1-Flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-12b-it": {
+          "displayName": "Gemma 3 12B IT",
+          "description": "Open multimodal Gemma instruction model for multilingual text generation and image understanding",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-27b-it": {
+          "displayName": "Gemma 3 27B IT",
+          "description": "Largest open Gemma 3 instruction model for multilingual text generation and visual understanding",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-4b-it": {
+          "displayName": "Gemma 3 4B IT",
+          "description": "Open multimodal Gemma instruction model for efficient text generation and image understanding",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -5737,8 +7473,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -5758,8 +7499,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-E4B-it": {
@@ -5779,8 +7526,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -5797,8 +7550,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -5815,8 +7572,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
@@ -5833,8 +7595,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -5851,14 +7618,18 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
           "displayName": "MiniMax-M2.7",
           "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 196608,
           "maxOutputTokens": 131072,
           "lastUpdated": "2026-03-18",
@@ -5868,8 +7639,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -5886,14 +7661,20 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
           "displayName": "Kimi K2.5",
           "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 262144,
           "maxOutputTokens": 32768,
           "knowledgeCutoff": "2025-01",
@@ -5908,8 +7689,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -5930,8 +7717,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -5952,8 +7745,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -5970,11 +7769,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
@@ -5991,8 +7799,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Nemotron-3-Nano-30B-A3B": {
@@ -6011,8 +7823,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": {
@@ -6029,8 +7845,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -6047,11 +7870,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -6068,11 +7899,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -6089,8 +7928,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -6107,8 +7950,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -6126,8 +7973,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
@@ -6145,8 +7996,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Max": {
@@ -6164,8 +8019,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -6183,8 +8042,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -6202,8 +8065,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -6220,8 +8088,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -6238,8 +8113,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -6257,8 +8139,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -6276,8 +8164,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -6294,8 +8188,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -6312,8 +8212,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -6330,8 +8237,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -6348,8 +8261,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -6366,11 +8283,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -6387,12 +8312,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-Max": {
@@ -6409,8 +8343,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -6427,8 +8368,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3": {
@@ -6436,7 +8383,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 64000,
+          "inputLimit": 192000,
+          "maxOutputTokens": 128000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-06",
           "capabilities": {
@@ -6445,8 +8393,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -6462,8 +8414,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -6480,8 +8438,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -6502,8 +8466,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -6524,8 +8495,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6": {
@@ -6546,8 +8522,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7": {
@@ -6568,14 +8548,18 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7-Flash": {
           "displayName": "GLM-4.7-Flash",
           "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 202752,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-04",
@@ -6587,14 +8571,18 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
           "displayName": "GLM-5",
           "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 202752,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-12",
@@ -6609,8 +8597,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -6631,8 +8623,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -6649,12 +8645,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3": {
@@ -6671,11 +8676,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -6692,58 +8705,120 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
       "deepseek": {
-        "deepseek-v4-flash": {
-          "displayName": "DeepSeek V4 Flash",
-          "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding",
+        "deepseek-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
           "lifecycle": "active",
           "contextWindow": 1000000,
           "maxOutputTokens": 384000,
           "knowledgeCutoff": "2025-05",
           "structuredOutput": true,
-          "lastUpdated": "2026-07-31",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "deepseek-v4-flash-vision-exp": {
-          "displayName": "DeepSeek V4 Flash Vision Exp",
-          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
-          "lifecycle": "beta",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
-          "structuredOutput": true,
-          "lastUpdated": "2026-08-21",
+          "lastUpdated": "2026-09-10",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4-flash": {
+          "displayName": "DeepSeek V4 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -6760,12 +8835,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -6785,12 +8867,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -6807,12 +8928,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/deepseek-v4p1-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/glm-5p2": {
@@ -6828,54 +8988,80 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/glm-5p3": {
           "displayName": "GLM 5.3",
           "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
           "lifecycle": "active",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 131072,
+          "contextWindow": 1048573,
+          "maxOutputTokens": 262144,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-28",
+          "lastUpdated": "2026-09-07",
           "capabilities": {
             "vision": false,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/glm-5p3-flash": {
           "displayName": "GLM 5.3 Flash",
           "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
           "lifecycle": "active",
-          "contextWindow": 1000000,
+          "contextWindow": 1048573,
           "maxOutputTokens": 131072,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-26",
+          "lastUpdated": "2026-09-07",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -6891,11 +9077,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/inkling": {
@@ -6911,8 +9105,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k2p6": {
@@ -6931,8 +9131,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k2p7-code": {
@@ -6951,8 +9156,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/kimi-k3": {
@@ -6969,12 +9179,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/minimax-m3": {
@@ -6990,11 +9210,44 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/mistral-large-3-fp8": {
+          "displayName": "Mistral Large 3 675B Instruct 2512",
+          "description": "Mistral's largest general model for enterprise agents, coding, and multilingual reasoning",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 262144,
+          "knowledgeCutoff": "2024-11",
+          "lastUpdated": "2025-12-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/muse-glimmer-30b": {
@@ -7012,11 +9265,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
@@ -7035,8 +9298,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
@@ -7056,8 +9323,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/qwen3p7-plus": {
@@ -7073,12 +9344,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/models/qwen3p8-2p4t-a95b": {
+          "displayName": "Qwen3.8 2.4T A95B",
+          "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-12",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/models/qwen3p8-max": {
@@ -7097,8 +9406,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/routers/glm-5p2-fast": {
@@ -7114,12 +9427,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "accounts/fireworks/routers/glm-5p3-fast": {
+          "displayName": "GLM 5.3 Fast",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "contextWindow": 1048572,
+          "maxOutputTokens": 262144,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-07",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "accounts/fireworks/routers/kimi-k3-fast": {
@@ -7136,12 +9485,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -7160,11 +9519,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "claude-fable-5.1": {
+          "displayName": "Claude Fable 5.1",
+          "description": "Claude model for demanding reasoning and long-horizon agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-06",
+          "lastUpdated": "2026-09-01",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4.5": {
@@ -7182,49 +9586,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "claude-opus-4.5": {
-          "displayName": "Claude Opus 4.5 (latest)",
-          "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-          "lifecycle": "active",
-          "contextWindow": 200000,
-          "inputLimit": 168000,
-          "maxOutputTokens": 32000,
-          "knowledgeCutoff": "2025-05",
-          "lastUpdated": "2025-11-24",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "claude-opus-4.6": {
-          "displayName": "Claude Opus 4.6",
-          "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
-          "lifecycle": "active",
-          "contextWindow": 200000,
-          "inputLimit": 168000,
-          "maxOutputTokens": 32000,
-          "knowledgeCutoff": "2025-05-31",
-          "lastUpdated": "2026-03-13",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.7": {
@@ -7242,11 +9611,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4.8": {
@@ -7264,11 +9645,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -7287,49 +9680,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "claude-sonnet-4": {
-          "displayName": "Claude Sonnet 4 (latest)",
-          "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
-          "lifecycle": "active",
-          "contextWindow": 216000,
-          "inputLimit": 128000,
-          "maxOutputTokens": 16000,
-          "knowledgeCutoff": "2025-03-31",
-          "lastUpdated": "2025-05-22",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "claude-sonnet-4.5": {
-          "displayName": "Claude Sonnet 4.5 (latest)",
-          "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
-          "lifecycle": "active",
-          "contextWindow": 200000,
-          "inputLimit": 168000,
-          "maxOutputTokens": 32000,
-          "knowledgeCutoff": "2025-07-31",
-          "lastUpdated": "2025-09-29",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4.6": {
@@ -7347,11 +9714,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -7368,34 +9746,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "gemini-3.1-pro-preview": {
-          "displayName": "Gemini 3.1 Pro Preview",
-          "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
-          "lifecycle": "active",
-          "contextWindow": 1000000,
-          "inputLimit": 936000,
-          "maxOutputTokens": 64000,
-          "knowledgeCutoff": "2025-01",
-          "structuredOutput": true,
-          "lastUpdated": "2026-02-19",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
-          },
-          "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -7414,11 +9781,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -7437,11 +9817,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -7460,31 +9851,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "gpt-4.1": {
-          "displayName": "GPT-4.1",
-          "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
+        "gemini-3.8-flash": {
+          "displayName": "Gemini 3.8 Flash",
+          "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
           "lifecycle": "active",
-          "contextWindow": 128000,
-          "inputLimit": 128000,
-          "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2024-04",
+          "contextWindow": 1000000,
+          "inputLimit": 936000,
+          "maxOutputTokens": 64000,
           "structuredOutput": true,
-          "lastUpdated": "2025-04-14",
+          "lastUpdated": "2026-09-02",
           "capabilities": {
             "vision": true,
-            "reasoning": false,
+            "reasoning": true,
             "functionCalling": true
           },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-mini": {
@@ -7503,51 +9914,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "gpt-5.2": {
-          "displayName": "GPT-5.2",
-          "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
-          "lifecycle": "active",
-          "contextWindow": 400000,
-          "inputLimit": 272000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2025-08-31",
-          "structuredOutput": true,
-          "lastUpdated": "2025-12-11",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "gpt-5.2-codex": {
-          "displayName": "GPT-5.2 Codex",
-          "description": "Code-specialist GPT for repository edits, reviews, and long-running software agents",
-          "lifecycle": "active",
-          "contextWindow": 400000,
-          "inputLimit": 272000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2025-08-31",
-          "structuredOutput": true,
-          "lastUpdated": "2025-12-11",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -7566,11 +9946,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -7589,11 +9980,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -7612,11 +10015,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -7635,8 +10049,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -7655,11 +10074,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -7678,11 +10109,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -7701,11 +10145,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -7724,11 +10181,59 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gpt-6-astra": {
+          "displayName": "GPT-6 Astra",
+          "description": "GPT-6 Astra is OpenAI's most capable model for complex reasoning, coding, computer use, research, and document creation.",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -7746,11 +10251,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -7769,11 +10283,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -7792,8 +10316,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -7810,11 +10339,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mai-code-1-flash-picker": {
@@ -7833,11 +10371,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mai-code-1.1-flash": {
@@ -7855,11 +10401,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -7878,8 +10434,17 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "deep-research-preview-04-2026": {
@@ -7896,8 +10461,17 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-2.5-computer-use-preview-10-2025": {
@@ -7914,8 +10488,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash": {
@@ -7936,8 +10515,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash-image": {
@@ -7954,8 +10541,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-2.5-flash-lite": {
@@ -7976,8 +10569,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-flash-preview-tts": {
@@ -7994,8 +10595,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-2.5-pro": {
@@ -8013,8 +10618,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-2.5-pro-preview-tts": {
@@ -8031,8 +10644,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-3-flash-preview": {
@@ -8050,11 +10667,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-pro-image": {
@@ -8071,11 +10701,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3-pro-image-preview": {
@@ -8092,8 +10731,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-image": {
@@ -8110,11 +10755,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-image-preview": {
@@ -8131,11 +10787,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-lite": {
@@ -8153,11 +10819,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-flash-lite-image": {
@@ -8175,11 +10854,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gemini-3.1-flash-lite-preview": {
@@ -8197,11 +10885,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-flash-live-preview": {
@@ -8219,11 +10920,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "gemini-3.1-flash-tts-preview": {
@@ -8240,8 +10954,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -8259,11 +10977,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-pro-preview-customtools": {
@@ -8281,11 +11011,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -8303,11 +11045,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -8325,11 +11080,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-live-translate-preview": {
@@ -8346,8 +11114,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["audio", "text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "audio",
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -8365,11 +11138,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -8387,11 +11173,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gemini-3.8-flash": {
+          "displayName": "Gemini 3.8 Flash",
+          "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-embedding-001": {
@@ -8408,8 +11239,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-embedding-2": {
@@ -8426,8 +11261,16 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-flash-latest": {
@@ -8445,11 +11288,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-flash-lite-latest": {
@@ -8467,11 +11322,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-omni-flash-preview": {
@@ -8487,8 +11355,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "gemma-4-26b-a4b-it": {
@@ -8508,8 +11382,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemma-4-31b-it": {
@@ -8529,8 +11408,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "lyria-3-clip-preview": {
@@ -8548,8 +11432,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "lyria-3-pro-preview": {
@@ -8567,8 +11457,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "veo-3.1-fast-generate-preview": {
@@ -8584,8 +11480,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "veo-3.1-generate-preview": {
@@ -8601,8 +11503,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "veo-3.1-lite-generate-preview": {
@@ -8618,8 +11525,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         }
       },
@@ -8638,8 +11550,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "canopylabs/orpheus-arabic-saudi": {
@@ -8655,8 +11571,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "canopylabs/orpheus-v1-english": {
@@ -8672,8 +11592,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "groq/compound": {
@@ -8689,8 +11613,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "groq/compound-mini": {
@@ -8706,8 +11634,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "llama-3.1-8b-instant": {
@@ -8724,8 +11656,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "llama-3.3-70b-versatile": {
@@ -8742,8 +11678,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-prompt-guard-2-22m": {
@@ -8759,8 +11699,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-prompt-guard-2-86m": {
@@ -8776,8 +11720,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -8794,11 +11742,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -8815,11 +11771,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -8836,11 +11800,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -8857,11 +11829,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "default"]
+            "efforts": [
+              "none",
+              "default"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -8878,11 +11858,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "default", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "default",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "whisper-large-v3": {
@@ -8898,8 +11889,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "whisper-large-v3-turbo": {
@@ -8915,8 +11910,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -8936,8 +11935,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -8954,8 +11957,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -8972,8 +11979,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -8990,8 +12001,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -9008,8 +12023,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -9026,8 +12045,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -9045,8 +12068,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -9064,11 +12091,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -9086,11 +12150,17 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -9107,11 +12177,124 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-ai/DeepSeek-V4.1-Flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-12b-it": {
+          "displayName": "Gemma 3 12B IT",
+          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-27b-it": {
+          "displayName": "Gemma 3 27B IT",
+          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-4b-it": {
+          "displayName": "Gemma 3 4B IT",
+          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 131072,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -9128,8 +12311,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -9146,8 +12334,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.1-8B-Instruct": {
@@ -9165,8 +12358,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct": {
@@ -9184,8 +12381,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2": {
@@ -9201,8 +12402,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.1": {
@@ -9219,8 +12424,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -9236,8 +12445,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -9254,8 +12467,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -9272,8 +12489,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Instruct": {
@@ -9290,8 +12512,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Instruct-0905": {
@@ -9308,8 +12534,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2-Thinking": {
@@ -9326,8 +12556,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -9344,8 +12578,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -9362,8 +12602,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -9381,8 +12627,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -9399,11 +12650,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -9420,11 +12680,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -9441,11 +12709,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-Coder-32B-Instruct": {
@@ -9462,8 +12738,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B": {
@@ -9481,8 +12761,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -9499,8 +12783,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -9517,8 +12805,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -9535,8 +12827,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -9554,8 +12850,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -9573,8 +12873,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -9591,8 +12895,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-Next": {
@@ -9609,8 +12917,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Embedding-4B": {
@@ -9627,8 +12939,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Embedding-8B": {
@@ -9645,8 +12961,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -9663,8 +12983,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Thinking": {
@@ -9681,8 +13005,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -9700,8 +13028,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -9719,11 +13052,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -9740,8 +13082,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -9758,8 +13105,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -9776,8 +13128,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -9794,11 +13151,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -9815,8 +13182,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -9833,8 +13205,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -9851,8 +13228,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -9869,11 +13251,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -9890,11 +13280,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -9911,8 +13310,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -9929,11 +13332,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3": {
@@ -9941,7 +13354,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 64000,
+          "inputLimit": 192000,
+          "maxOutputTokens": 128000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-06",
           "capabilities": {
@@ -9950,11 +13364,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -9971,11 +13393,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -9991,8 +13422,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2-Flash": {
@@ -10009,8 +13445,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -10028,12 +13468,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"],
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -10051,12 +13501,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"],
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5": {
@@ -10073,8 +13533,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -10091,8 +13555,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5V": {
@@ -10109,8 +13577,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6": {
@@ -10127,8 +13600,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.6V-Flash": {
@@ -10147,8 +13624,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7": {
@@ -10165,8 +13647,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -10184,8 +13670,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -10201,8 +13691,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -10218,8 +13712,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -10236,8 +13734,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3": {
@@ -10254,11 +13756,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -10275,11 +13785,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10299,12 +13818,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "k3-256k": {
@@ -10322,11 +13851,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-for-coding": {
@@ -10345,8 +13883,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-for-coding-highspeed": {
@@ -10365,8 +13909,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10384,8 +13934,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -10401,8 +13955,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -10418,8 +13976,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -10435,8 +13997,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -10452,8 +14018,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -10469,8 +14039,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -10489,8 +14063,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10508,8 +14088,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -10525,8 +14109,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -10542,8 +14130,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -10559,8 +14151,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -10576,8 +14172,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -10593,8 +14193,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -10613,8 +14217,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10633,8 +14243,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.1": {
@@ -10651,8 +14265,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5": {
@@ -10669,8 +14287,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -10687,8 +14309,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7": {
@@ -10705,8 +14331,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -10723,8 +14353,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMax-M3": {
@@ -10744,8 +14378,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -10764,8 +14404,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-2512": {
@@ -10782,8 +14426,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-latest": {
@@ -10800,8 +14448,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-medium-2507": {
@@ -10818,8 +14470,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-medium-latest": {
@@ -10836,8 +14492,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-small-2505": {
@@ -10854,8 +14514,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "devstral-small-2507": {
@@ -10872,8 +14536,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "labs-devstral-small-2512": {
@@ -10891,8 +14559,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "magistral-medium-latest": {
@@ -10909,8 +14582,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "magistral-small": {
@@ -10927,8 +14604,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ministral-3b-latest": {
@@ -10945,8 +14626,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ministral-8b-latest": {
@@ -10963,8 +14648,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-embed": {
@@ -10980,8 +14669,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-2411": {
@@ -10998,8 +14691,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-2512": {
@@ -11016,8 +14713,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-latest": {
@@ -11034,8 +14736,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2505": {
@@ -11052,8 +14759,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2508": {
@@ -11070,8 +14782,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-2604": {
@@ -11088,11 +14805,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-medium-latest": {
@@ -11109,11 +14834,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-nemo": {
@@ -11130,8 +14863,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-2506": {
@@ -11148,8 +14885,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-2603": {
@@ -11166,11 +14908,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-small-latest": {
@@ -11187,11 +14937,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mistral-7b": {
@@ -11208,8 +14966,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mistral-nemo": {
@@ -11226,8 +14988,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mixtral-8x22b": {
@@ -11244,8 +15010,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "open-mixtral-8x7b": {
@@ -11262,8 +15032,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pixtral-12b": {
@@ -11280,8 +15054,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pixtral-large-latest": {
@@ -11298,8 +15077,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voxtral-mini-latest": {
@@ -11315,8 +15099,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voxtral-mini-tts-latest": {
@@ -11332,8 +15120,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "voxtral-small-latest": {
@@ -11349,8 +15141,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-glm-5-2": {
@@ -11367,127 +15164,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
       "moonshot": {
-        "kimi-k2-0711-preview": {
-          "displayName": "Kimi K2 0711",
-          "description": "Kimi model for long-context chat, coding, and agentic reasoning",
-          "lifecycle": "active",
-          "contextWindow": 131072,
-          "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2024-10",
-          "lastUpdated": "2025-07-14",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kimi-k2-0905-preview": {
-          "displayName": "Kimi K2 0905",
-          "description": "Kimi model for long-context chat, coding, and agentic reasoning",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "knowledgeCutoff": "2024-10",
-          "lastUpdated": "2025-09-05",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kimi-k2-thinking": {
-          "displayName": "Kimi K2 Thinking",
-          "description": "Thinking Kimi model for slower research passes, planning, and hard technical questions",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "knowledgeCutoff": "2024-08",
-          "lastUpdated": "2025-11-06",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kimi-k2-thinking-turbo": {
-          "displayName": "Kimi K2 Thinking Turbo",
-          "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "knowledgeCutoff": "2024-08",
-          "lastUpdated": "2025-11-06",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kimi-k2-turbo-preview": {
-          "displayName": "Kimi K2 Turbo",
-          "description": "Fast Kimi model for responsive chat, coding help, and agent loops",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "knowledgeCutoff": "2024-10",
-          "lastUpdated": "2025-09-05",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "kimi-k2.5": {
-          "displayName": "Kimi K2.5",
-          "description": "Earlier Kimi frontier model for long-context agents, coding, and multimodal work",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 262144,
-          "knowledgeCutoff": "2025-01",
-          "structuredOutput": true,
-          "lastUpdated": "2026-01",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
-          }
-        },
         "kimi-k2.6": {
           "displayName": "Kimi K2.6",
           "description": "Multimodal Kimi workhorse for agent loops, coding tasks, and visual context",
@@ -11506,8 +15198,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -11525,8 +15223,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code-highspeed": {
@@ -11544,8 +15248,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -11562,12 +15272,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -11586,8 +15306,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baai/bge-m3": {
@@ -11604,8 +15328,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "black-forest-labs/flux_1-kontext-dev": {
@@ -11622,8 +15350,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux_1-schnell": {
@@ -11643,8 +15376,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux_2-klein-4b": {
@@ -11662,8 +15399,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "black-forest-labs/flux.1-dev": {
@@ -11681,8 +15423,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seed-oss-36b-instruct": {
@@ -11700,8 +15446,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-flash": {
@@ -11719,11 +15469,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-flash-0731": {
@@ -11742,11 +15500,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-pro": {
@@ -11764,11 +15530,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/deepseek-v4-pro-0813": {
@@ -11786,11 +15560,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high", "max"]
+            "efforts": [
+              "none",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-2-2b-it": {
@@ -11808,8 +15590,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-12b-it": {
@@ -11826,8 +15612,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-4b-it": {
@@ -11844,8 +15635,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-e2b-it": {
@@ -11864,8 +15660,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-e4b-it": {
@@ -11884,8 +15685,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -11906,8 +15712,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/google-paligemma": {
@@ -11924,8 +15736,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/esm2-650m": {
@@ -11942,8 +15759,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/esmfold": {
@@ -11960,8 +15781,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-70b-instruct": {
@@ -11979,8 +15804,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-8b-instruct": {
@@ -11998,8 +15827,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-11b-vision-instruct": {
@@ -12018,8 +15851,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-1b-instruct": {
@@ -12038,8 +15876,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-3b-instruct": {
@@ -12057,8 +15899,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.2-90b-vision-instruct": {
@@ -12076,8 +15922,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.3-70b-instruct": {
@@ -12095,8 +15946,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-maverick-17b-128e-instruct": {
@@ -12115,8 +15970,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-guard-4-12b": {
@@ -12133,8 +15993,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -12153,11 +16018,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4-mini-instruct": {
@@ -12175,8 +16052,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4-multimodal-instruct": {
@@ -12195,8 +16076,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimaxai/minimax-m2.7": {
@@ -12213,8 +16098,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimaxai/minimax-m3": {
@@ -12234,8 +16123,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/magistral-small-2506": {
@@ -12254,8 +16149,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-14b-instruct-2512": {
@@ -12272,8 +16171,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-7b-instruct-v0.3": {
@@ -12291,8 +16195,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-3-675b-instruct-2512": {
@@ -12311,8 +16219,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3-instruct": {
@@ -12331,8 +16244,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3.5-128b": {
@@ -12350,11 +16268,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-nemotron": {
@@ -12371,8 +16297,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-4-119b-2603": {
@@ -12390,11 +16320,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -12411,8 +16349,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x7b-instruct": {
@@ -12429,8 +16371,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-instruct-0905": {
@@ -12448,8 +16394,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -12468,11 +16418,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -12490,12 +16454,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/active-speaker-detection": {
@@ -12512,8 +16486,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["video"],
-            "output": ["text"]
+            "input": [
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/bevformer": {
@@ -12530,8 +16508,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["video"],
-            "output": ["text"]
+            "input": [
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/cosmos-predict1-5b": {
@@ -12548,8 +16530,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "nvidia/cosmos-reason2-8b": {
@@ -12566,8 +16554,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/cosmos-transfer1-7b": {
@@ -12584,8 +16578,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "nvidia/cosmos-transfer2_5-2b": {
@@ -12602,8 +16602,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "nvidia/gliner-pii": {
@@ -12620,8 +16626,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
@@ -12638,8 +16648,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -12656,8 +16670,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-8b-v1": {
@@ -12677,8 +16695,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
@@ -12695,8 +16717,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
@@ -12713,8 +16740,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.1-nemotron-ultra-253b-v1": {
@@ -12734,8 +16765,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1": {
@@ -12755,8 +16790,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
@@ -12776,8 +16815,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-nemotron-embed-vl-1b-v2": {
@@ -12794,8 +16837,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/llama-nemotron-rerank-vl-1b-v2": {
@@ -12812,8 +16860,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/magpie-tts-zeroshot": {
@@ -12830,8 +16883,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "nvidia/nemotron-3-content-safety": {
@@ -12848,8 +16906,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -12870,8 +16932,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
@@ -12892,8 +16958,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -12913,8 +16986,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -12934,8 +17011,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning-30b-a3b": {
@@ -12956,8 +17037,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-content-safety-reasoning-4b": {
@@ -12974,8 +17059,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-mini-4b-instruct": {
@@ -12992,8 +17081,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -13010,8 +17103,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-voicechat": {
@@ -13028,8 +17127,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nv-embed-v1": {
@@ -13046,8 +17150,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nv-embedcode-7b-v1": {
@@ -13064,8 +17172,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nvidia-nemotron-nano-9b-v2": {
@@ -13086,8 +17198,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/rerank-qa-mistral-4b": {
@@ -13104,8 +17220,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/riva-translate-4b-instruct-v1.1": {
@@ -13122,8 +17242,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/sparsedrive": {
@@ -13140,8 +17264,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["video"],
-            "output": ["text"]
+            "input": [
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/streampetr": {
@@ -13158,8 +17286,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["video"],
-            "output": ["text"]
+            "input": [
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/studiovoice": {
@@ -13176,8 +17308,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/synthetic-video-detector": {
@@ -13194,8 +17330,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["video"],
-            "output": ["text"]
+            "input": [
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/usdcode": {
@@ -13212,8 +17352,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/usdvalidate": {
@@ -13230,8 +17374,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -13250,11 +17398,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -13272,11 +17428,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/whisper-large-v3": {
@@ -13294,8 +17458,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -13313,8 +17481,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-image": {
@@ -13332,8 +17504,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen/qwen-image-edit": {
@@ -13351,8 +17528,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "qwen/qwen2.5-coder-32b-instruct": {
@@ -13370,8 +17552,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-480b-a35b-instruct": {
@@ -13389,8 +17575,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -13408,8 +17598,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -13430,8 +17624,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -13453,8 +17654,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sarvamai/sarvam-m": {
@@ -13471,8 +17677,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/step-3.5-flash": {
@@ -13489,11 +17699,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/step-3.7-flash": {
@@ -13510,11 +17728,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -13531,8 +17761,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-10.7b-instruct": {
@@ -13549,8 +17785,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -13571,8 +17811,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -13590,12 +17834,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash:0731": {
@@ -13613,12 +17864,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -13634,12 +17892,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4.1-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemma4:31b": {
@@ -13659,8 +17956,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -13679,8 +17981,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -13697,11 +18003,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -13718,11 +18031,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3-flash": {
@@ -13739,11 +18060,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss:120b": {
@@ -13759,11 +18091,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-oss:20b": {
@@ -13779,11 +18119,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -13802,8 +18150,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -13822,8 +18175,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -13844,8 +18202,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -13862,12 +18225,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -13884,8 +18256,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -13904,8 +18280,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -13922,12 +18302,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral-large-3:675b": {
@@ -13943,8 +18334,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-nano:30b": {
@@ -13963,8 +18359,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-super": {
@@ -13983,8 +18383,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-ultra": {
@@ -14003,8 +18407,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5:397b": {
@@ -14023,8 +18431,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -14043,8 +18456,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-3.5-turbo": {
@@ -14062,8 +18481,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4": {
@@ -14081,8 +18504,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4-turbo": {
@@ -14100,8 +18527,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1": {
@@ -14119,8 +18551,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1-mini": {
@@ -14138,8 +18576,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4.1-nano": {
@@ -14157,8 +18601,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o": {
@@ -14176,8 +18625,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-05-13": {
@@ -14195,8 +18650,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-08-06": {
@@ -14214,8 +18674,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-2024-11-20": {
@@ -14233,8 +18698,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-4o-mini": {
@@ -14252,8 +18722,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5": {
@@ -14272,11 +18748,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-mini": {
@@ -14295,11 +18781,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-nano": {
@@ -14318,11 +18814,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-pro": {
@@ -14341,11 +18847,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1": {
@@ -14364,11 +18877,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2": {
@@ -14387,17 +18910,28 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-chat-latest": {
           "displayName": "GPT-5.2 Chat",
           "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 128000,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-08-31",
@@ -14409,11 +18943,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium"]
+            "efforts": [
+              "medium"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-pro": {
@@ -14432,17 +18973,26 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-chat-latest": {
           "displayName": "GPT-5.3 Chat (latest)",
           "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 128000,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-08-31",
@@ -14454,8 +19004,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -14474,11 +19029,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -14497,11 +19064,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -14520,11 +19099,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -14543,11 +19134,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -14566,11 +19168,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-pro": {
@@ -14589,11 +19202,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -14612,11 +19234,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5-pro": {
@@ -14635,11 +19269,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6": {
@@ -14658,11 +19302,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -14681,11 +19338,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -14704,11 +19374,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -14727,11 +19410,59 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gpt-6-astra": {
+          "displayName": "GPT-6 Astra",
+          "description": "GPT-6 Astra is OpenAI's most capable model for complex reasoning, coding, computer use, research, and document creation.",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-image-1": {
@@ -14748,8 +19479,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "gpt-image-1-mini": {
@@ -14766,8 +19502,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-image-1.5": {
@@ -14784,8 +19526,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "gpt-image-2": {
@@ -14802,8 +19550,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "gpt-realtime-2.1": {
@@ -14822,11 +19575,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "audio", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "o1": {
@@ -14844,11 +19610,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o1-pro": {
@@ -14866,11 +19642,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3": {
@@ -14888,11 +19673,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3-mini": {
@@ -14910,11 +19705,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o3-pro": {
@@ -14932,11 +19735,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "o4-mini": {
@@ -14954,11 +19766,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-3-large": {
@@ -14975,8 +19796,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-3-small": {
@@ -14993,8 +19818,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "text-embedding-ada-002": {
@@ -15011,8 +19840,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -15034,8 +19867,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-3-5-haiku": {
@@ -15052,8 +19889,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-fable-5": {
@@ -15070,11 +19913,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "claude-fable-5-1": {
+          "displayName": "Claude Fable 5.1",
+          "description": "Claude model for demanding reasoning and long-horizon agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-06",
+          "lastUpdated": "2026-09-01",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-haiku-4-5": {
@@ -15091,8 +19979,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-1": {
@@ -15109,8 +20003,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-5": {
@@ -15127,11 +20027,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-6": {
@@ -15148,11 +20058,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-7": {
@@ -15169,11 +20090,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-4-8": {
@@ -15190,11 +20123,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-opus-5": {
@@ -15211,11 +20156,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4": {
@@ -15232,8 +20189,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-5": {
@@ -15250,8 +20213,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-4-6": {
@@ -15268,11 +20237,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "claude-sonnet-5": {
@@ -15289,11 +20269,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash": {
@@ -15311,12 +20303,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-free": {
@@ -15335,11 +20335,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "displayName": "DeepSeek V4 Flash Vision Exp",
+          "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-21",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -15357,12 +20396,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-flash": {
@@ -15380,11 +20426,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3-pro": {
@@ -15402,11 +20461,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.1-pro": {
@@ -15424,11 +20494,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash": {
@@ -15446,11 +20528,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -15468,11 +20563,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.6-flash": {
@@ -15490,11 +20598,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gemini-3.7-flash": {
@@ -15512,11 +20633,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gemini-3.8-flash": {
+          "displayName": "Gemini 3.8 Flash",
+          "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6": {
@@ -15536,8 +20702,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7": {
@@ -15557,8 +20727,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-free": {
@@ -15579,8 +20753,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -15600,8 +20778,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-free": {
@@ -15622,8 +20804,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -15643,8 +20829,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -15661,11 +20851,79 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3": {
+          "displayName": "GLM-5.3",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "glm-5.3-flash": {
+          "displayName": "GLM-5.3-Flash",
+          "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-26",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5": {
@@ -15684,11 +20942,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-codex": {
@@ -15707,11 +20975,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5-nano": {
@@ -15730,11 +21007,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1": {
@@ -15753,11 +21040,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex": {
@@ -15776,11 +21073,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex-max": {
@@ -15799,11 +21105,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.1-codex-mini": {
@@ -15822,11 +21138,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2": {
@@ -15845,11 +21170,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.2-codex": {
@@ -15868,11 +21204,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex": {
@@ -15891,11 +21238,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -15914,11 +21273,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4": {
@@ -15937,11 +21305,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-mini": {
@@ -15960,11 +21340,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-nano": {
@@ -15983,11 +21375,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.4-pro": {
@@ -16006,11 +21410,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5": {
@@ -16029,11 +21443,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.5-pro": {
@@ -16052,11 +21478,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -16075,11 +21511,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-sol": {
@@ -16098,11 +21547,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-terra": {
@@ -16121,11 +21583,59 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gpt-6-astra": {
+          "displayName": "GPT-6 Astra",
+          "description": "GPT-6 Astra is OpenAI's most capable model for complex reasoning, coding, computer use, research, and document creation.",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -16142,11 +21652,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -16164,11 +21683,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-build-0.1": {
@@ -16185,8 +21714,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-code": {
@@ -16203,8 +21738,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-free": {
@@ -16212,6 +21751,7 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "deprecated",
           "contextWindow": 190000,
+          "inputLimit": 192000,
           "maxOutputTokens": 64000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-06",
@@ -16222,12 +21762,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-preview-free": {
@@ -16245,8 +21793,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2": {
@@ -16263,8 +21815,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2-thinking": {
@@ -16281,8 +21837,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -16302,8 +21862,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5-free": {
@@ -16324,8 +21890,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -16345,8 +21917,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -16364,8 +21942,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -16382,11 +21966,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"]
+            "efforts": [
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "laguna-s-2.1-free": {
@@ -16404,11 +21996,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-2.6-flash-free": {
@@ -16426,8 +22026,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-3.0-flash-fin-free": {
@@ -16448,8 +22052,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-3.0-flash-free": {
@@ -16467,11 +22075,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ling-3.0-tiny-free": {
@@ -16489,8 +22105,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "longcat-2.0-free": {
@@ -16510,8 +22130,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-flash-free": {
@@ -16529,8 +22153,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni-free": {
@@ -16548,8 +22176,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro-free": {
@@ -16567,8 +22202,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-free": {
@@ -16586,8 +22225,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.1": {
@@ -16604,8 +22250,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.1-free": {
@@ -16623,8 +22273,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -16641,8 +22295,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5-free": {
@@ -16660,8 +22318,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -16678,8 +22340,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -16695,8 +22361,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3-free": {
@@ -16717,8 +22389,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2": {
@@ -16735,11 +22413,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2-contributor-free": {
@@ -16757,11 +22449,97 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "muse-spark-1.3": {
+          "displayName": "Muse Spark 1.3",
+          "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for long-running agentic, multi-agent, and coding workflows. It improves long-horizon agent collaboration, instruction following, and coding efficiency relative to Muse Spark 1.2.",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "muse-spark-1.3-contributor-free": {
+          "displayName": "Muse Spark 1.3 Free",
+          "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for coding and agentic workflows.",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-super-free": {
@@ -16779,8 +22557,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3-ultra-free": {
@@ -16798,8 +22580,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nemotron-3.5-lightning-free": {
@@ -16817,8 +22603,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "north-mini-code-free": {
@@ -16837,11 +22627,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3-coder": {
@@ -16858,8 +22655,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -16879,8 +22680,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -16900,8 +22707,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus-free": {
@@ -16922,8 +22735,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ring-2.6-1t-free": {
@@ -16941,8 +22760,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "trinity-large-preview-free": {
@@ -16960,8 +22783,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-preview-f-free": {
@@ -16979,11 +22806,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -17003,11 +22840,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -17024,12 +22869,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-v4-pro": {
@@ -17047,11 +22901,49 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek-v4.1-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -17068,8 +22960,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -17086,8 +22982,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -17104,11 +23004,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -17125,15 +23032,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3-flash": {
-          "displayName": "GLM-5.3-Flash (2x usage)",
+          "displayName": "GLM-5.3-Flash",
           "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
           "lifecycle": "active",
           "contextWindow": 1000000,
@@ -17146,11 +23061,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "gpt-5.6-luna": {
@@ -17169,11 +23095,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -17190,11 +23129,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -17212,11 +23160,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3": {
@@ -17224,7 +23182,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 256000,
-          "maxOutputTokens": 64000,
+          "inputLimit": 192000,
+          "maxOutputTokens": 128000,
           "lastUpdated": "2026-07-06",
           "capabilities": {
             "vision": false,
@@ -17232,11 +23191,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy4-preview": {
@@ -17252,11 +23219,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -17273,8 +23247,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.6": {
@@ -17291,8 +23271,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.7-code": {
@@ -17310,8 +23296,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k3": {
@@ -17328,11 +23320,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"]
+            "efforts": [
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "longcat-2.0": {
@@ -17351,8 +23351,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni": {
@@ -17369,8 +23373,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro": {
@@ -17387,8 +23398,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -17405,8 +23420,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -17423,8 +23445,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -17441,8 +23467,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.7": {
@@ -17459,8 +23489,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m3": {
@@ -17480,8 +23514,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "muse-spark-1.2-contributor": {
@@ -17498,11 +23538,89 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "muse-spark-1.3-contributor": {
+          "displayName": "Muse Spark 1.3 Contributor",
+          "description": "Muse Spark 1.3 is a multimodal reasoning model from Meta for coding and agentic workflows.",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "omen-alpha": {
+          "displayName": "Omen Alpha",
+          "description": "oH man anothEr aLPha ModEl",
+          "lifecycle": "deprecated",
+          "contextWindow": 500000,
+          "maxOutputTokens": 128000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ox-alpha-free": {
@@ -17520,11 +23638,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.5-plus": {
@@ -17544,8 +23672,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.6-plus": {
@@ -17565,8 +23699,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-max": {
@@ -17585,8 +23725,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.7-plus": {
@@ -17605,8 +23749,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-flash": {
@@ -17623,12 +23773,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen3.8-max": {
@@ -17645,12 +23805,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -17669,15 +23839,27 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-haiku-latest": {
-          "displayName": "Anthropic Claude Haiku Latest",
+          "displayName": "Claude Haiku Latest",
           "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
           "lifecycle": "active",
           "contextWindow": 200000,
@@ -17693,8 +23875,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-opus-latest": {
@@ -17711,16 +23899,28 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~anthropic/claude-sonnet-latest": {
-          "displayName": "Anthropic Claude Sonnet Latest",
+          "displayName": "Claude Sonnet Latest",
           "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
           "lifecycle": "active",
           "contextWindow": 1000000,
@@ -17734,12 +23934,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~deepseek/deepseek-v4-flash-latest": {
@@ -17756,16 +23968,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~google/gemini-flash-latest": {
-          "displayName": "Google Gemini Flash Latest",
+          "displayName": "Gemini Flash Latest",
           "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
           "lifecycle": "active",
           "contextWindow": 1048576,
@@ -17779,15 +23999,27 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~google/gemini-pro-latest": {
-          "displayName": "Google Gemini Pro Latest",
+          "displayName": "Gemini Pro Latest",
           "description": "Advanced Gemini model for complex reasoning, coding, and multimodal analysis",
           "lifecycle": "active",
           "contextWindow": 1048576,
@@ -17801,15 +24033,27 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["audio", "pdf", "image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "audio",
+              "pdf",
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~moonshotai/kimi-latest": {
-          "displayName": "MoonshotAI Kimi Latest",
+          "displayName": "Kimi Latest",
           "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
           "lifecycle": "active",
           "contextWindow": 1048576,
@@ -17822,38 +24066,94 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "~openai/gpt-latest": {
-          "displayName": "OpenAI GPT Latest",
+        "~openai/gpt-astra-latest": {
+          "displayName": "GPT Astra Latest",
           "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
           "lifecycle": "active",
           "contextWindow": 1050000,
           "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2026-02-16",
           "structuredOutput": true,
-          "lastUpdated": "2026-04-27",
+          "lastUpdated": "2026-09-11",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "~openai/gpt-luna-latest": {
+          "displayName": "GPT Luna Latest",
+          "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-02-16",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-11",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~openai/gpt-mini-latest": {
-          "displayName": "OpenAI GPT Mini Latest",
+          "displayName": "GPT Mini Latest",
           "description": "Compact GPT model for low-latency assistance and high-volume workloads",
           "lifecycle": "active",
           "contextWindow": 400000,
@@ -17867,11 +24167,93 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "~openai/gpt-sol-latest": {
+          "displayName": "GPT Sol Latest",
+          "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-02-16",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-11",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "~openai/gpt-terra-latest": {
+          "displayName": "GPT Terra Latest",
+          "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-02-16",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-11",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~x-ai/grok-latest": {
@@ -17888,11 +24270,53 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "~z-ai/glm-flash-latest": {
+          "displayName": "GLM Flash Latest",
+          "description": "GLM vision model for visual reasoning, documents, and multimodal agents",
+          "lifecycle": "active",
+          "contextWindow": 1310720,
+          "maxOutputTokens": 131072,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-27",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "~z-ai/glm-latest": {
@@ -17909,11 +24333,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-2.0": {
@@ -17930,8 +24362,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-3.0": {
@@ -17948,8 +24384,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-3.0-mini": {
@@ -17966,8 +24406,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "aion-labs/aion-rp-llama-3.1-8b": {
@@ -17985,8 +24429,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-2-lite-v1": {
@@ -18006,8 +24454,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-lite-v1": {
@@ -18025,8 +24480,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-micro-v1": {
@@ -18044,8 +24504,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-premier-v1": {
@@ -18062,8 +24526,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-pro-v1": {
@@ -18081,8 +24550,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthracite-org/magnum-v4-72b": {
@@ -18100,8 +24574,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -18119,8 +24597,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -18138,11 +24621,57 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "anthropic/claude-fable-5.1": {
+          "displayName": "Claude Fable 5.1",
+          "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-06",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-01",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -18163,8 +24692,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -18185,8 +24720,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -18207,8 +24748,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -18229,8 +24776,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -18248,12 +24801,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -18271,35 +24835,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "anthropic/claude-opus-4.7-fast": {
-          "displayName": "Claude Opus 4.7 (Fast)",
-          "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-          "lifecycle": "active",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2026-01-31",
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-16",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -18317,35 +24870,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "anthropic/claude-opus-4.8-fast": {
-          "displayName": "Claude Opus 4.8 (Fast)",
-          "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-          "lifecycle": "active",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2026-01",
-          "structuredOutput": true,
-          "lastUpdated": "2026-05-28",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5": {
@@ -18363,35 +24905,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "anthropic/claude-opus-5-fast": {
-          "displayName": "Claude Opus 5 (Fast)",
-          "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
-          "lifecycle": "active",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 128000,
-          "knowledgeCutoff": "2026-05",
-          "structuredOutput": true,
-          "lastUpdated": "2026-07-24",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -18412,8 +24943,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -18434,8 +24971,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -18453,12 +24996,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -18476,12 +25030,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -18498,8 +25064,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baidu/ernie-4.5-vl-424b-a47b": {
@@ -18520,8 +25090,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-1.6": {
@@ -18541,8 +25116,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-1.6-flash": {
@@ -18562,8 +25143,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2-1-turbo": {
@@ -18583,8 +25170,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-code": {
@@ -18601,12 +25194,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-lite": {
@@ -18623,12 +25226,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance-seed/seed-2.0-mini": {
@@ -18645,12 +25259,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/ui-tars-1.5-7b": {
@@ -18668,8 +25293,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -18687,8 +25317,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-a": {
@@ -18706,8 +25340,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r-08-2024": {
@@ -18725,8 +25363,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r-plus-08-2024": {
@@ -18744,8 +25386,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/command-r7b-12-2024": {
@@ -18763,8 +25409,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/north-mini-code:free": {
@@ -18785,8 +25435,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat": {
@@ -18804,8 +25458,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat-v3-0324": {
@@ -18823,8 +25481,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat-v3.1": {
@@ -18832,7 +25494,7 @@
           "description": "DeepSeek chat model for instruction following, coding, and analysis",
           "lifecycle": "active",
           "contextWindow": 163840,
-          "maxOutputTokens": 144900,
+          "maxOutputTokens": 32768,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-08-21",
@@ -18845,8 +25507,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1": {
@@ -18864,8 +25530,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1-0528": {
@@ -18883,8 +25553,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1-distill-llama-70b": {
@@ -18905,8 +25579,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -18927,8 +25605,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -18949,8 +25631,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -18971,8 +25657,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -18990,12 +25680,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -19013,12 +25710,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -19026,8 +25731,8 @@
           "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
           "lifecycle": "active",
           "contextWindow": 1048576,
-          "maxOutputTokens": 384000,
-          "structuredOutput": false,
+          "maxOutputTokens": 943718,
+          "structuredOutput": true,
           "lastUpdated": "2026-08-21",
           "capabilities": {
             "vision": true,
@@ -19035,12 +25740,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -19048,7 +25762,7 @@
           "description": "Open MoE flagship with million-token context for coding and long agent runs",
           "lifecycle": "active",
           "contextWindow": 1048576,
-          "maxOutputTokens": 393216,
+          "maxOutputTokens": 384000,
           "knowledgeCutoff": "2025-05",
           "structuredOutput": true,
           "lastUpdated": "2026-04-24",
@@ -19058,12 +25772,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -19071,7 +25792,7 @@
           "description": "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes",
           "lifecycle": "active",
           "contextWindow": 1048576,
-          "maxOutputTokens": 384000,
+          "maxOutputTokens": 393216,
           "structuredOutput": true,
           "lastUpdated": "2026-08-22",
           "capabilities": {
@@ -19080,12 +25801,52 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek/deepseek-v4.1-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "Fast DeepSeek model for efficient chat, coding help, and agent loops",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 384000,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -19106,8 +25867,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -19128,8 +25894,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -19147,8 +25921,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -19169,8 +25949,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -19188,8 +25976,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro-preview": {
@@ -19207,8 +26003,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro-preview-05-06": {
@@ -19226,8 +26029,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -19245,12 +26056,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-pro-image": {
@@ -19268,12 +26092,18 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3-pro-image-preview": {
-          "displayName": "Nano Banana Pro",
+          "displayName": "Nano Banana Pro Preview",
           "description": "Nano Banana Pro for higher-fidelity image generation and design-heavy edits",
           "lifecycle": "active",
           "contextWindow": 65536,
@@ -19287,8 +26117,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -19306,16 +26142,25 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text", "image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
-          "displayName": "Nano Banana 2",
+          "displayName": "Nano Banana 2 Preview",
           "description": "Image model for prompt-driven generation, editing, and visual design workflows",
           "lifecycle": "active",
           "contextWindow": 65536,
@@ -19329,12 +26174,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text", "image"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -19352,12 +26206,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -19375,12 +26242,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"],
+            "efforts": [
+              "minimal",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -19398,12 +26274,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -19421,11 +26310,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview-customtools": {
@@ -19443,11 +26344,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -19465,11 +26378,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -19487,11 +26413,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.6-flash": {
@@ -19509,11 +26448,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.7-flash": {
@@ -19531,11 +26483,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemini-3.8-flash": {
+          "displayName": "Gemini 3.8 Flash",
+          "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-2-27b-it": {
@@ -19553,36 +26550,21 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-12b-it": {
-          "displayName": "Gemma 3 12B",
+          "displayName": "Gemma 3 12B IT",
           "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
           "lifecycle": "active",
           "contextWindow": 131072,
           "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2024-08-31",
-          "structuredOutput": true,
-          "lastUpdated": "2025-03-13",
-          "capabilities": {
-            "vision": true,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "google/gemma-3-27b-it": {
-          "displayName": "Gemma 3 27B",
-          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
-          "lifecycle": "active",
-          "contextWindow": 131072,
-          "maxOutputTokens": 117964,
-          "knowledgeCutoff": "2024-08-31",
+          "knowledgeCutoff": "2024-08",
           "structuredOutput": true,
           "lastUpdated": "2025-03-12",
           "capabilities": {
@@ -19591,27 +26573,61 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemma-3-27b-it": {
+          "displayName": "Gemma 3 27B IT",
+          "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 117964,
+          "knowledgeCutoff": "2024-08",
+          "structuredOutput": true,
+          "lastUpdated": "2025-03-12",
+          "capabilities": {
+            "vision": true,
+            "reasoning": false,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3-4b-it": {
-          "displayName": "Gemma 3 4B",
+          "displayName": "Gemma 3 4B IT",
           "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
           "lifecycle": "active",
           "contextWindow": 131072,
           "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2024-08-31",
+          "knowledgeCutoff": "2024-08",
           "structuredOutput": true,
-          "lastUpdated": "2025-03-13",
+          "lastUpdated": "2025-03-12",
           "capabilities": {
             "vision": true,
             "reasoning": false,
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -19619,7 +26635,7 @@
           "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 32768,
           "structuredOutput": true,
           "lastUpdated": "2026-04-02",
           "capabilities": {
@@ -19631,8 +26647,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it:free": {
@@ -19653,8 +26675,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -19674,8 +26702,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it:free": {
@@ -19696,8 +26730,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/lyria-3-clip-preview": {
@@ -19715,8 +26755,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "google/lyria-3-pro-preview": {
@@ -19734,8 +26780,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "gryphe/mythomax-l2-13b": {
@@ -19753,8 +26805,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ibm-granite/granite-4.0-h-micro": {
@@ -19771,26 +26827,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "ibm-granite/granite-4.1-8b": {
-          "displayName": "Granite 4.1 8B",
-          "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
-          "lifecycle": "active",
-          "contextWindow": 131072,
-          "maxOutputTokens": 117964,
-          "structuredOutput": true,
-          "lastUpdated": "2026-04-30",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ibm-granite/granite-4.2-8b": {
@@ -19807,11 +26849,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inception/mercury-2": {
@@ -19828,15 +26878,54 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inception/mercury-2.5": {
+          "displayName": "Mercury 2.5",
+          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+          "lifecycle": "active",
+          "contextWindow": 260000,
+          "maxOutputTokens": 65536,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-08",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash": {
-          "displayName": "Ling-3.0-flash",
+          "displayName": "Ling 3.0 Flash",
           "description": "Efficient model for low-latency assistance, extraction, and routine automation",
           "lifecycle": "active",
           "contextWindow": 262144,
@@ -19852,8 +26941,37 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-fin": {
+          "displayName": "Ling 3.0 Flash Fin",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 235929,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-27",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash-fin:free": {
@@ -19874,8 +26992,137 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-sante:free": {
+          "displayName": "Ling 3.0 Flash Sante (free)",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 32768,
+          "structuredOutput": false,
+          "lastUpdated": "2026-09-04",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-vl": {
+          "displayName": "Ling 3.0 Flash VL",
+          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 32768,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-vl:free": {
+          "displayName": "Ling 3.0 Flash VL (free)",
+          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 32768,
+          "structuredOutput": false,
+          "lastUpdated": "2026-09-10",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inference-net/schematron-v2-small": {
+          "displayName": "Schematron V2 Small",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 128000,
+          "maxOutputTokens": 4096,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-12",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inference-net/schematron-v2-turbo": {
+          "displayName": "Schematron V2 Turbo",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 128000,
+          "maxOutputTokens": 8192,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-12",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -19892,8 +27139,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -19910,8 +27161,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "liquid/lfm-2.5-2.6b:free": {
@@ -19929,8 +27184,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mancer/weaver": {
@@ -19948,8 +27207,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meituan/longcat-2.0": {
@@ -19969,17 +27232,21 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.1-70b-instruct": {
-          "displayName": "Llama 3.1 70B Instruct",
+          "displayName": "Llama-3.1-70B-Instruct",
           "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
           "lifecycle": "active",
           "contextWindow": 131072,
-          "maxOutputTokens": 16384,
-          "knowledgeCutoff": "2023-12-31",
+          "maxOutputTokens": 8192,
+          "knowledgeCutoff": "2023-12",
           "structuredOutput": true,
           "lastUpdated": "2024-07-23",
           "capabilities": {
@@ -19988,8 +27255,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.1-8b-instruct": {
@@ -20007,8 +27278,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.2-1b-instruct": {
@@ -20026,8 +27301,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.2-3b-instruct": {
@@ -20045,8 +27324,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-3.3-70b-instruct": {
@@ -20054,7 +27337,7 @@
           "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
           "lifecycle": "active",
           "contextWindow": 131072,
-          "maxOutputTokens": 115200,
+          "maxOutputTokens": 16384,
           "knowledgeCutoff": "2023-12",
           "structuredOutput": true,
           "lastUpdated": "2024-12-06",
@@ -20064,8 +27347,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -20083,8 +27370,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-4-scout": {
@@ -20102,8 +27394,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/llama-guard-4-12b": {
@@ -20121,8 +27418,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -20130,7 +27432,7 @@
           "description": "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding.",
           "lifecycle": "active",
           "contextWindow": 131072,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2026-01-04",
           "structuredOutput": true,
           "lastUpdated": "2026-08-10",
@@ -20140,11 +27442,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.1": {
@@ -20161,11 +27473,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2": {
@@ -20182,11 +27508,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -20203,11 +27543,97 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-spark-1.3": {
+          "displayName": "Muse Spark 1.3",
+          "description": "Open Llama multimodal model for image understanding and text reasoning",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 943718,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-spark-1.3-contributor": {
+          "displayName": "Muse Spark 1.3 Contributor",
+          "description": "Open Llama multimodal model for image understanding and text reasoning",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 943718,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/phi-4": {
@@ -20225,8 +27651,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "microsoft/wizardlm-2-8x22b": {
@@ -20244,8 +27674,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-01": {
@@ -20263,8 +27697,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m1": {
@@ -20285,8 +27724,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2": {
@@ -20303,8 +27746,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2-her": {
@@ -20321,8 +27768,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -20339,8 +27790,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -20357,8 +27812,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -20375,27 +27834,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "minimax/minimax-m2.7:free": {
-          "displayName": "MiniMax M2.7 (free)",
-          "description": "MiniMax model for chat, coding, office work, and agentic tasks",
-          "lifecycle": "active",
-          "contextWindow": 196608,
-          "maxOutputTokens": 176947,
-          "structuredOutput": false,
-          "lastUpdated": "2026-03-18",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -20415,30 +27859,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
-          }
-        },
-        "minimax/minimax-m3:free": {
-          "displayName": "MiniMax M3 (free)",
-          "description": "MiniMax multimodal coding model for long-context reasoning and agent tasks",
-          "lifecycle": "active",
-          "contextWindow": 1048576,
-          "maxOutputTokens": 943718,
-          "structuredOutput": false,
-          "lastUpdated": "2026-06-01",
-          "isFree": true,
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/codestral-2508": {
@@ -20456,8 +27884,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/devstral-2512": {
@@ -20475,8 +27908,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-14b-2512": {
@@ -20493,8 +27931,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-3b-2512": {
@@ -20511,8 +27954,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/ministral-8b-2512": {
@@ -20529,8 +27977,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large": {
@@ -20548,8 +28001,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-2407": {
@@ -20567,8 +28025,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-large-2512": {
@@ -20586,8 +28049,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3": {
@@ -20605,8 +28074,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3-5": {
@@ -20623,11 +28098,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-medium-3.1": {
@@ -20645,8 +28129,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-nemo": {
@@ -20664,8 +28154,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-saba": {
@@ -20683,8 +28177,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-24b-instruct-2501": {
@@ -20702,8 +28201,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-2603": {
@@ -20721,11 +28224,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-3.1-24b-instruct": {
@@ -20743,15 +28254,20 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mistral-small-3.2-24b-instruct": {
           "displayName": "Mistral Small 3.2 24B",
           "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
           "lifecycle": "active",
-          "contextWindow": 131072,
+          "contextWindow": 256000,
           "maxOutputTokens": 16384,
           "knowledgeCutoff": "2023-10-31",
           "structuredOutput": true,
@@ -20762,8 +28278,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -20781,8 +28302,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistralai/voxtral-small-24b-2507": {
@@ -20792,15 +28318,21 @@
           "contextWindow": 32768,
           "maxOutputTokens": 26214,
           "structuredOutput": true,
-          "lastUpdated": "2025-10-30",
+          "lastUpdated": "2025-07-15",
           "capabilities": {
             "vision": false,
             "reasoning": false,
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2": {
@@ -20818,8 +28350,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -20837,8 +28373,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -20846,7 +28386,7 @@
           "description": "Thinking Kimi model for slower research passes, planning, and hard technical questions",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 100352,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2024-08",
           "structuredOutput": true,
           "lastUpdated": "2025-11-06",
@@ -20856,8 +28396,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -20878,8 +28422,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -20900,8 +28449,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -20919,8 +28473,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -20937,12 +28496,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-fast": {
@@ -20959,8 +28528,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-large": {
@@ -20977,50 +28550,74 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "nex-agi/nex-n2-mini": {
-          "displayName": "Nex-N2-Mini",
+        "nex-agi/nex-n2.5-mini:free": {
+          "displayName": "Nex-N2.5-Mini (free)",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 262144,
+          "maxOutputTokens": 235929,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-08",
+          "isFree": true,
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "nex-agi/nex-n2.5-pro:free": {
+          "displayName": "Nex-N2.5-Pro (free)",
           "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
           "lifecycle": "active",
           "contextWindow": 262144,
           "maxOutputTokens": 235929,
           "structuredOutput": true,
-          "lastUpdated": "2026-06-24",
+          "lastUpdated": "2026-09-08",
+          "isFree": true,
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "toggle": true
+            "efforts": [
+              "none",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          }
-        },
-        "nex-agi/nex-n2-pro": {
-          "displayName": "Nex-N2-Pro",
-          "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
-          "lifecycle": "active",
-          "contextWindow": 262144,
-          "maxOutputTokens": 235929,
-          "structuredOutput": false,
-          "lastUpdated": "2026-06-08",
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-3-llama-3.1-405b": {
@@ -21038,8 +28635,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-3-llama-3.1-70b": {
@@ -21057,8 +28658,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nousresearch/hermes-4-405b": {
@@ -21079,30 +28684,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "nousresearch/hermes-4-70b": {
-          "displayName": "Hermes 4 70B",
-          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-          "lifecycle": "active",
-          "contextWindow": 131072,
-          "maxOutputTokens": 117964,
-          "knowledgeCutoff": "2024-08-31",
-          "structuredOutput": false,
-          "lastUpdated": "2025-08-26",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": false
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -21110,7 +28697,7 @@
           "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 228000,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2025-12-15",
           "capabilities": {
@@ -21122,8 +28709,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -21144,15 +28735,22 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
           "displayName": "Nemotron 3 Super 120B A12B",
           "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
           "lifecycle": "active",
-          "contextWindow": 1000000,
+          "contextWindow": 262144,
           "maxOutputTokens": 16384,
           "structuredOutput": true,
           "lastUpdated": "2026-03-11",
@@ -21162,12 +28760,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium"],
+            "efforts": [
+              "low",
+              "medium"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b:free": {
@@ -21185,12 +28790,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium"],
+            "efforts": [
+              "low",
+              "medium"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -21198,7 +28810,7 @@
           "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 32768,
           "structuredOutput": true,
           "lastUpdated": "2026-06-04",
           "capabilities": {
@@ -21207,12 +28819,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high"],
+            "efforts": [
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -21230,12 +28849,45 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high"],
+            "efforts": [
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "nvidia/nemotron-3.5-content-safety": {
+          "displayName": "Nemotron 3.5 Content Safety",
+          "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
+          "lifecycle": "active",
+          "contextWindow": 131072,
+          "maxOutputTokens": 117964,
+          "structuredOutput": false,
+          "lastUpdated": "2026-06-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": false
+          },
+          "thinkingOptions": {
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-content-safety:free": {
@@ -21256,8 +28908,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -21277,8 +28934,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning:free": {
@@ -21299,8 +28960,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -21318,8 +28983,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-0613": {
@@ -21337,8 +29006,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-16k": {
@@ -21356,8 +29029,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo-instruct": {
@@ -21375,8 +29052,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4": {
@@ -21394,8 +29075,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo": {
@@ -21413,8 +29098,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo-preview": {
@@ -21432,8 +29122,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1": {
@@ -21451,8 +29145,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -21470,8 +29170,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -21489,8 +29195,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o": {
@@ -21508,8 +29220,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-05-13": {
@@ -21527,8 +29245,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-08-06": {
@@ -21546,8 +29270,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-2024-11-20": {
@@ -21565,8 +29295,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini": {
@@ -21584,8 +29320,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-2024-07-18": {
@@ -21603,8 +29345,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -21623,11 +29371,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-image": {
@@ -21645,8 +29404,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["image", "text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5-image-mini": {
@@ -21663,8 +29429,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["image", "text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini": {
@@ -21683,11 +29456,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-nano": {
@@ -21706,11 +29490,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-pro": {
@@ -21729,11 +29524,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1": {
@@ -21752,11 +29555,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -21775,11 +29589,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -21798,11 +29621,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -21821,12 +29654,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -21845,11 +29687,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-chat": {
@@ -21867,8 +29721,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -21887,11 +29747,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -21910,11 +29780,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -21933,11 +29813,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -21956,11 +29848,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-image-2": {
@@ -21977,11 +29881,24 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["image", "text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -22000,11 +29917,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -22023,11 +29952,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -22046,11 +29987,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -22069,11 +30020,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -22092,11 +30055,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -22115,11 +30088,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna-pro": {
@@ -22138,11 +30124,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -22161,11 +30160,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol-pro": {
@@ -22184,11 +30196,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -22207,11 +30232,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra-pro": {
@@ -22230,11 +30268,92 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "openai/gpt-6-astra": {
+          "displayName": "GPT-6 Astra",
+          "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "openai/gpt-6-astra-pro": {
+          "displayName": "GPT-6 Astra Pro",
+          "description": "Frontier GPT model for professional reasoning, coding, and multimodal work",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "maxOutputTokens": 128000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-audio": {
@@ -22251,8 +30370,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-audio-mini": {
@@ -22269,8 +30394,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-chat-latest": {
@@ -22287,8 +30418,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -22305,11 +30442,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -22326,15 +30471,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
-          "displayName": "gpt-oss-safeguard-20b",
+          "displayName": "GPT OSS Safeguard 20B",
           "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
           "lifecycle": "active",
           "contextWindow": 131072,
@@ -22347,11 +30500,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1": {
@@ -22372,8 +30533,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1-pro": {
@@ -22394,8 +30561,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3": {
@@ -22416,8 +30589,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini": {
@@ -22438,8 +30617,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini-high": {
@@ -22457,11 +30641,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-pro": {
@@ -22482,8 +30673,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "pdf", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "pdf",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini": {
@@ -22504,8 +30701,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini-high": {
@@ -22523,11 +30726,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/auto": {
@@ -22544,8 +30755,17 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf", "video"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf",
+              "video"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "openrouter/bodybuilder": {
@@ -22562,8 +30782,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/free": {
@@ -22582,8 +30806,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/fusion": {
@@ -22600,8 +30829,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openrouter/pareto-code": {
@@ -22618,8 +30851,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perceptron/perceptron-mk1": {
@@ -22639,8 +30876,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar": {
@@ -22657,8 +30900,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-deep-research": {
@@ -22678,8 +30926,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro": {
@@ -22696,8 +30948,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro-search": {
@@ -22714,8 +30971,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -22735,8 +30997,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -22756,8 +31023,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1:free": {
@@ -22778,8 +31049,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -22799,8 +31074,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-xs-2.1:free": {
@@ -22821,8 +31100,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-72b-instruct": {
@@ -22840,8 +31123,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-7b-instruct": {
@@ -22859,8 +31146,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-2.5-coder-32b-instruct": {
@@ -22878,8 +31169,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-plus": {
@@ -22897,8 +31192,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen-plus-2025-07-28": {
@@ -22916,8 +31215,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen2.5-vl-72b-instruct": {
@@ -22925,7 +31228,7 @@
           "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 128000,
-          "maxOutputTokens": 28800,
+          "maxOutputTokens": 115200,
           "knowledgeCutoff": "2024-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-02-01",
@@ -22935,8 +31238,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-14b": {
@@ -22944,7 +31252,7 @@
           "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
           "lifecycle": "active",
           "contextWindow": 131072,
-          "maxOutputTokens": 16384,
+          "maxOutputTokens": 8192,
           "knowledgeCutoff": "2025-03-31",
           "structuredOutput": true,
           "lastUpdated": "2025-04-28",
@@ -22957,8 +31265,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b": {
@@ -22979,8 +31291,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b-2507": {
@@ -22998,8 +31314,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-235b-a22b-thinking-2507": {
@@ -23017,8 +31337,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b": {
@@ -23027,7 +31351,7 @@
           "lifecycle": "active",
           "contextWindow": 131072,
           "maxOutputTokens": 16384,
-          "structuredOutput": false,
+          "structuredOutput": true,
           "lastUpdated": "2025-04-28",
           "capabilities": {
             "vision": false,
@@ -23038,8 +31362,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b-instruct-2507": {
@@ -23047,7 +31375,7 @@
           "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 32000,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-06-30",
           "structuredOutput": true,
           "lastUpdated": "2025-07-29",
@@ -23057,8 +31385,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-30b-a3b-thinking-2507": {
@@ -23076,8 +31408,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-32b": {
@@ -23098,8 +31434,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-8b": {
@@ -23120,8 +31460,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder": {
@@ -23139,8 +31483,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-30b-a3b-instruct": {
@@ -23158,8 +31506,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-flash": {
@@ -23177,8 +31529,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-next": {
@@ -23196,8 +31552,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -23215,8 +31575,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max": {
@@ -23234,8 +31598,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max-thinking": {
@@ -23255,8 +31623,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -23264,7 +31636,7 @@
           "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 235929,
+          "maxOutputTokens": 16384,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2025-09",
@@ -23274,8 +31646,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-next-80b-a3b-thinking": {
@@ -23283,7 +31659,7 @@
           "description": "Efficient Qwen thinking model for local reasoning, math, and coding agents",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 32768,
+          "maxOutputTokens": 235929,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2025-09",
@@ -23293,8 +31669,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-235b-a22b-instruct": {
@@ -23312,8 +31692,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-235b-a22b-thinking": {
@@ -23331,8 +31716,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-30b-a3b-instruct": {
@@ -23350,8 +31740,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-30b-a3b-thinking": {
@@ -23369,8 +31764,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-32b-instruct": {
@@ -23387,8 +31787,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-8b-instruct": {
@@ -23405,8 +31810,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-vl-8b-thinking": {
@@ -23423,8 +31833,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -23432,7 +31847,7 @@
           "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 81920,
+          "maxOutputTokens": 65536,
           "structuredOutput": true,
           "lastUpdated": "2026-02-23",
           "capabilities": {
@@ -23444,8 +31859,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-27b": {
@@ -23465,8 +31886,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-35b-a3b": {
@@ -23474,7 +31901,7 @@
           "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 235929,
+          "maxOutputTokens": 16384,
           "structuredOutput": true,
           "lastUpdated": "2026-02-23",
           "capabilities": {
@@ -23486,8 +31913,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -23495,7 +31928,7 @@
           "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 65536,
+          "maxOutputTokens": 235929,
           "structuredOutput": true,
           "lastUpdated": "2026-02-15",
           "capabilities": {
@@ -23507,8 +31940,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-9b": {
@@ -23528,8 +31967,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-flash-02-23": {
@@ -23549,8 +31994,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus-02-15": {
@@ -23571,8 +32022,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus-20260420": {
@@ -23592,8 +32049,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -23601,7 +32064,7 @@
           "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
-          "maxOutputTokens": 235929,
+          "maxOutputTokens": 65536,
           "structuredOutput": true,
           "lastUpdated": "2026-04-22",
           "capabilities": {
@@ -23613,8 +32076,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-35b-a3b": {
@@ -23634,8 +32103,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-flash": {
@@ -23655,8 +32130,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-max-preview": {
@@ -23677,8 +32158,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -23699,8 +32184,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-flash": {
@@ -23721,8 +32212,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-max": {
@@ -23742,8 +32239,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -23764,8 +32265,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-2.4t-a95b": {
@@ -23773,7 +32279,7 @@
           "description": "Open-weight sparse MoE (2.4T total, 95B active), the open-weight twin of Qwen3.8 Max for coding, research, complex reasoning, and agentic workflows",
           "lifecycle": "active",
           "contextWindow": 1048576,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 131072,
           "structuredOutput": true,
           "lastUpdated": "2026-08-12",
           "capabilities": {
@@ -23782,11 +32288,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -23803,12 +32317,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.8-flash": {
@@ -23828,29 +32352,47 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
-        "qwen/qwen3.8-max": {
-          "displayName": "Qwen3.8 Max",
+        "qwen/qwen3.8-max-0902": {
+          "displayName": "Qwen3.8 Max 0902",
           "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 1000000,
           "maxOutputTokens": 131072,
           "structuredOutput": true,
-          "lastUpdated": "2026-08-03",
+          "lastUpdated": "2026-09-02",
           "capabilities": {
             "vision": true,
             "reasoning": true,
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "rekaai/reka-edge": {
@@ -23867,8 +32409,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "rekaai/reka-flash-3": {
@@ -23886,8 +32434,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "relace/relace-apply-3": {
@@ -23904,8 +32456,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "relace/relace-search": {
@@ -23922,8 +32478,43 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "sakana/fugu-max": {
+          "displayName": "Fugu Max",
+          "description": "Multi-agent model for routing expert agents across complex analytical tasks",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-11",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/fugu-ultra": {
@@ -23940,11 +32531,52 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh", "max"]
+            "efforts": [
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "sakana/fugu-ultra-v2": {
+          "displayName": "Fugu Ultra v2",
+          "description": "Quality-first multi-agent model for hard research, analysis, and competitions",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-08-28",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-11",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/sakana-namazu": {
@@ -23961,11 +32593,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3-lunaris-8b": {
@@ -23983,8 +32624,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3.1-euryale-70b": {
@@ -24002,8 +32647,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sao10k/l3.3-euryale-70b": {
@@ -24021,8 +32670,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -24040,8 +32693,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -24060,11 +32717,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hunyuan-a13b-instruct": {
@@ -24085,8 +32752,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-1.8b": {
@@ -24103,8 +32774,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-30b-a3b": {
@@ -24121,8 +32796,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-7b": {
@@ -24139,8 +32818,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3": {
@@ -24148,6 +32831,7 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 262144,
+          "inputLimit": 192000,
           "maxOutputTokens": 128000,
           "structuredOutput": true,
           "lastUpdated": "2026-07-06",
@@ -24157,11 +32841,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3-preview": {
@@ -24178,11 +32870,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy4-preview": {
@@ -24199,11 +32899,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/cydonia-24b-v4.1": {
@@ -24221,8 +32929,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/skyfall-36b-v2": {
@@ -24240,8 +32952,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thedrummer/unslopnemo-12b": {
@@ -24249,7 +32965,7 @@
           "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
           "lifecycle": "active",
           "contextWindow": 1024000,
-          "maxOutputTokens": 26214,
+          "maxOutputTokens": 819200,
           "knowledgeCutoff": "2024-04-30",
           "structuredOutput": true,
           "lastUpdated": "2024-11-08",
@@ -24259,8 +32975,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -24277,11 +32997,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -24298,11 +33031,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling-small:free": {
@@ -24320,11 +33066,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling:free": {
@@ -24342,11 +33101,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "undi95/remm-slerp-l2-13b": {
@@ -24354,7 +33126,7 @@
           "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
           "lifecycle": "active",
           "contextWindow": 6144,
-          "maxOutputTokens": 4096,
+          "maxOutputTokens": 5529,
           "knowledgeCutoff": "2023-06-30",
           "structuredOutput": true,
           "lastUpdated": "2023-07-22",
@@ -24364,8 +33136,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-pro-3": {
@@ -24385,8 +33161,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "upstage/solar-pro4": {
@@ -24406,8 +33186,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "writer/palmyra-x5": {
@@ -24424,8 +33208,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.20": {
@@ -24446,8 +33234,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.20-multi-agent": {
@@ -24465,11 +33259,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.3": {
@@ -24486,11 +33291,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.5": {
@@ -24507,11 +33323,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.6": {
@@ -24529,11 +33355,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -24550,8 +33387,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -24572,8 +33415,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -24594,8 +33444,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5": {
@@ -24616,8 +33470,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -24638,8 +33496,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5v": {
@@ -24660,8 +33522,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6": {
@@ -24682,8 +33549,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v": {
@@ -24704,8 +33575,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7": {
@@ -24726,16 +33603,20 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flash": {
           "displayName": "GLM-4.7-Flash",
           "description": "Budget GLM lane for fast coding help, routing, and everyday automation",
           "lifecycle": "active",
-          "contextWindow": 202752,
-          "maxOutputTokens": 16384,
+          "contextWindow": 200000,
+          "maxOutputTokens": 117964,
           "knowledgeCutoff": "2025-04",
           "structuredOutput": true,
           "lastUpdated": "2026-01-19",
@@ -24748,8 +33629,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5": {
@@ -24769,8 +33654,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -24790,8 +33679,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.1": {
@@ -24811,8 +33704,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -24820,7 +33717,7 @@
           "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
           "lifecycle": "active",
           "contextWindow": 1048576,
-          "maxOutputTokens": 262144,
+          "maxOutputTokens": 182476,
           "structuredOutput": true,
           "lastUpdated": "2026-06-13",
           "capabilities": {
@@ -24829,35 +33726,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "z-ai/glm-5.2:free": {
-          "displayName": "GLM 5.2 (free)",
-          "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
-          "lifecycle": "active",
-          "contextWindow": 256000,
-          "maxOutputTokens": 230400,
-          "structuredOutput": true,
-          "lastUpdated": "2026-06-13",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.3": {
@@ -24865,7 +33746,7 @@
           "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
           "lifecycle": "active",
           "contextWindow": 1310720,
-          "maxOutputTokens": 131072,
+          "maxOutputTokens": 943718,
           "structuredOutput": true,
           "lastUpdated": "2026-08-14",
           "capabilities": {
@@ -24874,11 +33755,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.3-flash": {
@@ -24895,11 +33784,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -24919,8 +33818,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["image", "text", "video"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -24939,8 +33844,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "ByteDance-Seed/Seed-OSS-36B-Instruct": {
@@ -24957,8 +33866,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -24975,8 +33888,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -24993,8 +33910,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -25014,8 +33935,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.1-Terminus": {
@@ -25035,8 +33960,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -25056,8 +33985,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3.2-Exp": {
@@ -25077,8 +34010,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -25096,8 +34033,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -25115,8 +34056,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -25133,8 +34078,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -25151,8 +34100,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionAI/Ling-flash-2.0": {
@@ -25169,8 +34122,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -25187,8 +34144,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -25205,8 +34166,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -25223,8 +34189,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -25241,8 +34212,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -25259,8 +34234,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-72B-Instruct": {
@@ -25277,8 +34256,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct": {
@@ -25295,8 +34278,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-14B": {
@@ -25316,8 +34303,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -25334,8 +34325,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-30B-A3B-Instruct-2507": {
@@ -25352,8 +34347,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -25373,8 +34372,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-8B": {
@@ -25394,8 +34397,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -25412,8 +34419,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -25430,8 +34441,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -25448,8 +34463,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -25466,8 +34486,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Instruct": {
@@ -25484,8 +34509,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Thinking": {
@@ -25502,8 +34532,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-32B-Instruct": {
@@ -25520,8 +34555,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-32B-Thinking": {
@@ -25538,8 +34578,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-VL-8B-Instruct": {
@@ -25556,8 +34601,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -25574,8 +34624,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -25592,8 +34646,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -25610,8 +34668,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -25628,8 +34690,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -25646,8 +34712,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -25664,8 +34734,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -25682,8 +34756,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -25700,8 +34778,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hunyuan-A13B-Instruct": {
@@ -25721,8 +34803,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/Hy3-preview": {
@@ -25738,8 +34824,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -25756,8 +34846,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -25774,8 +34868,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -25792,8 +34890,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -25810,11 +34912,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5V-Turbo": {
@@ -25833,8 +34942,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -25854,8 +34968,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-2-16k": {
@@ -25873,8 +34991,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash": {
@@ -25892,11 +35014,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -25914,11 +35043,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -25936,11 +35072,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-tts-2": {
@@ -25956,8 +35102,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "stepaudio-2.5-asr": {
@@ -25973,8 +35123,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepaudio-2.5-tts": {
@@ -25990,8 +35144,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -26011,8 +35169,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-2-16k": {
@@ -26030,8 +35192,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash": {
@@ -26049,11 +35215,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -26071,11 +35244,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -26093,11 +35273,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-tts-2": {
@@ -26113,8 +35303,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "stepaudio-2.5-asr": {
@@ -26130,8 +35324,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepaudio-2.5-tts": {
@@ -26147,8 +35345,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -26168,11 +35370,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -26190,11 +35399,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -26212,11 +35428,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -26236,11 +35462,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.5-flash-2603": {
@@ -26258,11 +35491,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high"]
+            "efforts": [
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-3.7-flash": {
@@ -26280,11 +35520,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "step-router-v1": {
@@ -26302,8 +35552,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -26324,8 +35578,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -26342,8 +35600,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -26360,8 +35622,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V3-1": {
@@ -26381,8 +35647,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -26400,12 +35670,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -26422,12 +35699,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -26444,12 +35728,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"],
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "essentialai/Rnj-1-Instruct": {
@@ -26466,8 +35758,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-3n-E4B-it": {
@@ -26484,8 +35780,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31B-it": {
@@ -26503,8 +35803,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "LiquidAI/LFM2-24B-A2B": {
@@ -26520,8 +35825,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -26538,8 +35847,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
@@ -26555,8 +35868,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -26572,8 +35889,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -26590,8 +35911,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -26608,8 +35933,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -26629,8 +35959,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -26651,8 +35986,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -26669,8 +36010,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -26687,11 +36032,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -26711,8 +36066,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -26729,11 +36088,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -26750,11 +36117,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "pearl-ai/gemma-4-31b-it": {
@@ -26770,8 +36145,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct-Turbo": {
@@ -26788,8 +36167,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
@@ -26806,8 +36189,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -26824,8 +36211,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3-Coder-Next-FP8": {
@@ -26842,8 +36233,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -26862,8 +36257,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -26883,8 +36283,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.6-Plus": {
@@ -26903,8 +36308,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -26920,8 +36329,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/Inkling": {
@@ -26938,11 +36351,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max", "xhigh", "high", "medium", "low", "none"]
+            "efforts": [
+              "max",
+              "xhigh",
+              "high",
+              "medium",
+              "low",
+              "none"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5": {
@@ -26962,8 +36388,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.1": {
@@ -26984,8 +36414,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.2": {
@@ -27002,12 +36436,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"],
+            "efforts": [
+              "high",
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3": {
@@ -27024,11 +36465,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -27045,11 +36494,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27071,8 +36530,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-2.0-instruct": {
@@ -27089,8 +36552,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-2.0-thinking": {
@@ -27107,8 +36574,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-t1": {
@@ -27125,8 +36596,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hunyuan-turbos": {
@@ -27143,8 +36618,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kimi-k2.5": {
@@ -27165,8 +36644,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax-m2.5": {
@@ -27183,8 +36668,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tc-code-latest": {
@@ -27201,8 +36690,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27212,7 +36705,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 256000,
-          "maxOutputTokens": 64000,
+          "inputLimit": 192000,
+          "maxOutputTokens": 128000,
           "lastUpdated": "2026-07-06",
           "isFree": true,
           "capabilities": {
@@ -27221,12 +36715,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy4-preview": {
@@ -27242,12 +36743,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27257,7 +36765,8 @@
           "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
           "lifecycle": "active",
           "contextWindow": 256000,
-          "maxOutputTokens": 64000,
+          "inputLimit": 192000,
+          "maxOutputTokens": 128000,
           "lastUpdated": "2026-07-06",
           "isFree": true,
           "capabilities": {
@@ -27266,12 +36775,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy3-preview": {
@@ -27288,12 +36804,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "hy4-preview": {
@@ -27309,12 +36833,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"],
+            "efforts": [
+              "none",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -27336,8 +36867,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-235b": {
@@ -27354,8 +36889,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-30b": {
@@ -27375,8 +36914,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3-32b": {
@@ -27396,8 +36939,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen-3.6-max-preview": {
@@ -27416,8 +36963,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-235b-a22b-thinking": {
@@ -27434,8 +36985,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder": {
@@ -27452,8 +37009,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-30b-a3b": {
@@ -27470,8 +37031,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-next": {
@@ -27489,8 +37054,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-coder-plus": {
@@ -27507,8 +37076,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-0.6b": {
@@ -27524,8 +37097,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-4b": {
@@ -27541,8 +37118,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-embedding-8b": {
@@ -27558,8 +37139,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max": {
@@ -27576,8 +37161,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max-preview": {
@@ -27594,8 +37183,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-max-thinking": {
@@ -27612,8 +37205,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-next-80b-a3b-instruct": {
@@ -27630,8 +37227,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-next-80b-a3b-thinking": {
@@ -27648,8 +37249,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-235b-a22b-instruct": {
@@ -27667,8 +37272,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-instruct": {
@@ -27685,8 +37295,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3-vl-thinking": {
@@ -27703,8 +37318,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.5-flash": {
@@ -27724,8 +37345,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.5-plus": {
@@ -27745,8 +37372,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.6-27b": {
@@ -27766,8 +37399,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.6-plus": {
@@ -27787,8 +37426,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-flash": {
@@ -27805,8 +37450,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-max": {
@@ -27825,8 +37476,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.7-plus": {
@@ -27846,8 +37501,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-2.4t-a95b": {
@@ -27864,11 +37525,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-27b": {
@@ -27885,11 +37555,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-flash": {
@@ -27909,8 +37590,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-flash-next": {
@@ -27927,11 +37614,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/qwen3.8-max": {
@@ -27947,11 +37643,51 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "alibaba/qwen3.8-max-0902": {
+          "displayName": "Qwen3.8 Max 0902",
+          "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+          "lifecycle": "active",
+          "contextWindow": 991000,
+          "maxOutputTokens": 128000,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "alibaba/wan-v2.5-t2v-preview": {
@@ -27967,8 +37703,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.6-i2v": {
@@ -27984,8 +37724,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.6-i2v-flash": {
@@ -28001,8 +37745,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.6-r2v": {
@@ -28018,8 +37766,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.6-r2v-flash": {
@@ -28035,8 +37787,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.6-t2v": {
@@ -28052,8 +37808,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.7-r2v": {
@@ -28069,8 +37829,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v2.7-t2v": {
@@ -28086,8 +37850,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v3.0-video": {
@@ -28103,8 +37871,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "alibaba/wan-v3.0-video-prime": {
@@ -28120,8 +37893,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "amazon/nova-2-lite": {
@@ -28138,12 +37916,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-lite": {
@@ -28151,7 +37939,7 @@
           "description": "Efficient model for low-latency assistance, extraction, and routine automation",
           "lifecycle": "active",
           "contextWindow": 300000,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 10000,
           "knowledgeCutoff": "2024-10",
           "lastUpdated": "2024-12-03",
           "capabilities": {
@@ -28160,8 +37948,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-micro": {
@@ -28169,7 +37964,7 @@
           "description": "Efficient model for low-latency assistance, extraction, and routine automation",
           "lifecycle": "active",
           "contextWindow": 128000,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 10000,
           "knowledgeCutoff": "2024-10",
           "lastUpdated": "2024-12-03",
           "capabilities": {
@@ -28178,8 +37973,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/nova-pro": {
@@ -28187,7 +37986,7 @@
           "description": "Flagship model for demanding analysis, coding, and production agent workflows",
           "lifecycle": "active",
           "contextWindow": 300000,
-          "maxOutputTokens": 8192,
+          "maxOutputTokens": 10000,
           "knowledgeCutoff": "2024-10",
           "lastUpdated": "2024-12-03",
           "capabilities": {
@@ -28196,8 +37995,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "amazon/titan-embed-text-v2": {
@@ -28213,8 +38019,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -28231,8 +38041,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -28249,12 +38064,56 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "anthropic/claude-fable-5.1": {
+          "displayName": "Claude Fable 5.1",
+          "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-06",
+          "lastUpdated": "2026-09-01",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -28274,8 +38133,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -28292,8 +38157,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -28313,8 +38184,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -28331,12 +38208,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -28353,12 +38240,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -28375,12 +38273,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -28397,12 +38306,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5": {
@@ -28419,11 +38339,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -28440,11 +38372,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -28461,8 +38405,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -28480,8 +38430,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -28498,12 +38454,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -28520,12 +38486,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"],
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -28541,8 +38518,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bfl/flux-2-flex": {
@@ -28558,8 +38539,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-klein-4b": {
@@ -28575,8 +38560,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-klein-9b": {
@@ -28592,8 +38581,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-max": {
@@ -28609,8 +38602,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-2-pro": {
@@ -28626,8 +38623,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-3-video": {
@@ -28643,8 +38644,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bfl/flux-kontext-max": {
@@ -28660,8 +38665,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-kontext-pro": {
@@ -28677,8 +38686,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.0-fill": {
@@ -28694,8 +38707,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.1": {
@@ -28711,8 +38728,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bfl/flux-pro-1.1-ultra": {
@@ -28728,8 +38749,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seed-1.6": {
@@ -28749,8 +38774,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/seed-1.8": {
@@ -28767,12 +38797,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"],
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "bytedance/seedance-2.0": {
@@ -28788,8 +38828,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-2.0-fast": {
@@ -28805,8 +38850,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-2.0-mini": {
@@ -28822,8 +38872,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-2.5": {
@@ -28839,8 +38894,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-v1.0-pro": {
@@ -28856,8 +38915,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-v1.0-pro-fast": {
@@ -28873,8 +38936,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedance-v1.5-pro": {
@@ -28890,8 +38957,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "bytedance/seedream-4.0": {
@@ -28907,8 +38978,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-4.5": {
@@ -28924,8 +38999,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-5.0-lite": {
@@ -28941,8 +39020,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "bytedance/seedream-5.0-pro": {
@@ -28958,8 +39041,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "cohere/command-a": {
@@ -28976,8 +39063,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/embed-v4.0": {
@@ -28993,8 +39084,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v3.5": {
@@ -29010,8 +39105,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v4-fast": {
@@ -29027,8 +39126,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "cohere/rerank-v4-pro": {
@@ -29044,13 +39147,17 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-r1": {
           "displayName": "DeepSeek-R1",
-          "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
+          "description": "Classic open reasoning model for transparent math, coding, and deliberate problem solving",
           "lifecycle": "active",
           "contextWindow": 128000,
           "maxOutputTokens": 32768,
@@ -29059,28 +39166,15 @@
           "capabilities": {
             "vision": false,
             "reasoning": true,
-            "functionCalling": true
+            "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "deepseek/deepseek-v3": {
-          "displayName": "DeepSeek V3 0324",
-          "description": "DeepSeek chat model for instruction following, coding, and analysis",
-          "lifecycle": "active",
-          "contextWindow": 163840,
-          "maxOutputTokens": 163840,
-          "lastUpdated": "2024-12-26",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1": {
@@ -29099,8 +39193,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -29120,8 +39218,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -29139,8 +39241,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-thinking": {
@@ -29157,8 +39263,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -29176,12 +39286,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -29199,16 +39316,20 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
           "displayName": "DeepSeek V4 Flash Vision Exp",
           "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
           "lifecycle": "active",
-          "contextWindow": 1000000,
-          "maxOutputTokens": 384000,
+          "contextWindow": 1048576,
+          "maxOutputTokens": 1048576,
           "structuredOutput": true,
           "lastUpdated": "2026-08-21",
           "capabilities": {
@@ -29217,12 +39338,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -29240,12 +39369,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -29262,12 +39398,50 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "deepseek/deepseek-v4.1-flash": {
+          "displayName": "DeepSeek V4.1 Flash",
+          "description": "DeepSeek V4.1 Flash model for reasoning and agentic coding",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 393216,
+          "knowledgeCutoff": "2025-05",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-10",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
+            "toggle": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "fish-audio/s1": {
@@ -29283,8 +39457,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s1-free": {
@@ -29300,8 +39478,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2-pro": {
@@ -29317,8 +39499,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2-pro-free": {
@@ -29334,8 +39520,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2.1-pro": {
@@ -29351,8 +39541,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/s2.1-pro-free": {
@@ -29368,8 +39562,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "fish-audio/transcribe-1": {
@@ -29385,8 +39583,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "fish-audio/transcribe-1-free": {
@@ -29402,8 +39604,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -29424,8 +39630,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -29442,8 +39656,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -29464,8 +39684,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -29483,8 +39709,16 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash": {
@@ -29501,11 +39735,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-pro-image": {
@@ -29522,8 +39767,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -29540,11 +39791,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -29561,11 +39821,20 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "high"]
+            "efforts": [
+              "minimal",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -29583,11 +39852,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -29605,8 +39885,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -29624,11 +39910,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -29646,11 +39942,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -29668,11 +39975,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-transcribe": {
@@ -29688,8 +40006,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-transcribe-live": {
@@ -29705,8 +40027,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.6-flash": {
@@ -29724,11 +40050,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.7-flash": {
@@ -29746,11 +40083,45 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "google/gemini-3.8-flash": {
+          "displayName": "Gemini 3.8 Flash",
+          "description": "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows",
+          "lifecycle": "active",
+          "contextWindow": 1000000,
+          "maxOutputTokens": 65536,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-embedding-001": {
@@ -29767,8 +40138,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-embedding-2": {
@@ -29785,8 +40160,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-omni-flash-preview": {
@@ -29802,8 +40181,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -29820,8 +40205,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemma-4-31b-it": {
@@ -29838,8 +40229,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/text-embedding-005": {
@@ -29855,8 +40252,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/text-multilingual-embedding-002": {
@@ -29872,8 +40273,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/veo-3.0-fast-generate-001": {
@@ -29889,8 +40294,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "google/veo-3.0-generate-001": {
@@ -29906,8 +40315,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "google/veo-3.1-fast-generate-001": {
@@ -29923,8 +40336,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "google/veo-3.1-generate-001": {
@@ -29940,8 +40357,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "google/veo-3.1-lite-generate-001": {
@@ -29957,8 +40378,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "inception/mercury-2": {
@@ -29974,11 +40399,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inception/mercury-2.5": {
+          "displayName": "Mercury 2.5",
+          "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+          "lifecycle": "active",
+          "contextWindow": 260000,
+          "maxOutputTokens": 65536,
+          "lastUpdated": "2026-09-08",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inception/mercury-coder-small": {
@@ -29994,8 +40456,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -30011,8 +40477,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash-fin": {
@@ -30032,8 +40502,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-3.0-flash-fin-free": {
@@ -30053,8 +40527,56 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-sante": {
+          "displayName": "Ling 3.0 Flash Sante",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 256000,
+          "maxOutputTokens": 32000,
+          "lastUpdated": "2026-09-04",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "inclusionai/ling-3.0-flash-sante-free": {
+          "displayName": "Ling 3.0 Flash Sante (Free)",
+          "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+          "lifecycle": "active",
+          "contextWindow": 256000,
+          "maxOutputTokens": 32000,
+          "lastUpdated": "2026-09-04",
+          "isFree": true,
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "interfaze/interfaze-beta": {
@@ -30070,11 +40592,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "klingai/kling-v2.5-turbo-i2v": {
@@ -30090,8 +40622,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v2.5-turbo-t2v": {
@@ -30107,8 +40643,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v2.6-i2v": {
@@ -30124,8 +40664,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v2.6-motion-control": {
@@ -30141,8 +40685,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v2.6-t2v": {
@@ -30158,8 +40706,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v3.0-i2v": {
@@ -30175,8 +40727,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v3.0-motion-control": {
@@ -30192,8 +40748,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "klingai/kling-v3.0-t2v": {
@@ -30209,8 +40769,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "kwaipilot/kat-coder-air-v2.5": {
@@ -30226,8 +40790,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v1": {
@@ -30244,8 +40813,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -30261,8 +40834,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -30278,8 +40855,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-70b": {
@@ -30296,8 +40878,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.1-8b": {
@@ -30314,8 +40900,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-3.3-70b": {
@@ -30333,8 +40923,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-maverick": {
@@ -30352,8 +40946,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/llama-4-scout": {
@@ -30371,8 +40970,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -30390,11 +40994,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-image-1.0": {
@@ -30410,8 +41024,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["image"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "meta/muse-spark-1.1": {
@@ -30428,11 +41047,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2": {
@@ -30449,8 +41080,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -30466,8 +41103,71 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-spark-1.3": {
+          "displayName": "Muse Spark 1.3",
+          "description": "Open Llama multimodal model for image understanding and text reasoning",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 1048576,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "meta/muse-spark-1.3-contributor": {
+          "displayName": "Muse Spark 1.3 Contributor",
+          "description": "Open Llama multimodal model for image understanding and text reasoning",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 1048576,
+          "lastUpdated": "2026-09-02",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-h3": {
@@ -30483,8 +41183,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "minimax/minimax-h3-max": {
@@ -30500,8 +41205,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "minimax/minimax-m2": {
@@ -30518,8 +41228,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -30535,8 +41249,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1-lightning": {
@@ -30553,8 +41271,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -30570,8 +41292,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5-highspeed": {
@@ -30587,8 +41313,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -30604,26 +41334,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "minimax/minimax-m2.7-free": {
-          "displayName": "Minimax M2.7 (Free)",
-          "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
-          "lifecycle": "active",
-          "contextWindow": 196608,
-          "maxOutputTokens": 196608,
-          "lastUpdated": "2026-03-18",
-          "isFree": true,
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -30639,8 +41355,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -30659,29 +41379,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        },
-        "minimax/minimax-m3-free": {
-          "displayName": "MiniMax M3 (Free)",
-          "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
-          "lifecycle": "active",
-          "contextWindow": 1048576,
-          "maxOutputTokens": 1048576,
-          "lastUpdated": "2026-06-01",
-          "isFree": true,
-          "capabilities": {
-            "vision": true,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/codestral": {
@@ -30698,8 +41403,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/codestral-embed": {
@@ -30715,8 +41424,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/devstral-2": {
@@ -30733,8 +41446,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/devstral-small-2": {
@@ -30751,8 +41468,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-14b": {
@@ -30769,8 +41491,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-3b": {
@@ -30787,8 +41515,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/ministral-8b": {
@@ -30805,8 +41537,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-embed": {
@@ -30822,8 +41558,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-large-3": {
@@ -30840,8 +41580,13 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-medium": {
@@ -30858,8 +41603,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-medium-3.5": {
@@ -30875,11 +41625,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-nemo": {
@@ -30896,8 +41654,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/mistral-small": {
@@ -30914,8 +41677,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mistral/pixtral-12b": {
@@ -30932,8 +41700,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2": {
@@ -30949,8 +41722,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -30967,8 +41744,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -30989,8 +41770,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -31011,8 +41797,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -31030,8 +41821,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code-highspeed": {
@@ -31049,8 +41846,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -31067,8 +41870,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3-fast": {
@@ -31085,11 +41894,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-fast": {
@@ -31105,8 +41924,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "morph/morph-v3-large": {
@@ -31122,8 +41945,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -31142,8 +41969,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -31162,8 +41993,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -31182,8 +42017,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -31203,8 +42042,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -31223,8 +42066,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "nvidia/nemotron-nano-9b-v2": {
@@ -31243,8 +42091,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -31263,8 +42115,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4-turbo": {
@@ -31282,8 +42138,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1": {
@@ -31301,8 +42162,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-fast": {
@@ -31321,8 +42188,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -31340,8 +42213,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-mini-fast": {
@@ -31360,8 +42239,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -31379,8 +42264,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4.1-nano-fast": {
@@ -31399,8 +42289,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o": {
@@ -31418,8 +42314,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-fast": {
@@ -31438,8 +42340,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini": {
@@ -31457,8 +42365,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-fast": {
@@ -31477,8 +42391,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-mini-transcribe": {
@@ -31494,8 +42414,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-4o-transcribe": {
@@ -31511,8 +42435,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -31531,11 +42459,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-codex": {
@@ -31554,11 +42492,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-fast": {
@@ -31577,11 +42525,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini": {
@@ -31600,11 +42559,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-mini-fast": {
@@ -31623,11 +42592,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-nano": {
@@ -31646,11 +42626,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-pro": {
@@ -31669,11 +42659,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high"]
+            "efforts": [
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -31692,11 +42690,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -31715,11 +42723,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -31738,11 +42757,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-thinking": {
@@ -31760,11 +42789,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text", "image"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text",
+              "image"
+            ]
           }
         },
         "openai/gpt-5.1-thinking-fast": {
@@ -31781,8 +42822,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -31801,11 +42848,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -31824,11 +42883,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-fast": {
@@ -31847,11 +42917,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -31870,11 +42952,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -31893,11 +42985,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex-fast": {
@@ -31916,11 +43019,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -31939,11 +43053,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-fast": {
@@ -31962,11 +43088,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -31985,11 +43123,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini-fast": {
@@ -32008,11 +43158,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -32031,11 +43193,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -32054,11 +43228,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -32077,11 +43261,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-fast": {
@@ -32100,11 +43296,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -32123,11 +43331,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -32146,11 +43364,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna-fast": {
@@ -32169,11 +43400,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -32192,11 +43436,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol-fast": {
@@ -32215,11 +43472,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -32238,11 +43508,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra-fast": {
@@ -32261,11 +43544,95 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "openai/gpt-6-astra": {
+          "displayName": "GPT-6 Astra",
+          "description": "GPT-6 Astra is OpenAI's most capable model for complex reasoning, coding, computer use, research, and document creation.",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "knowledgeCutoff": "2026-04-30",
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "openai/gpt-6-astra-fast": {
+          "displayName": "GPT-6 Astra (Fast)",
+          "description": "Fast variant of GPT-6 Astra for low-latency assistance and high-volume workloads.",
+          "lifecycle": "active",
+          "contextWindow": 1050000,
+          "inputLimit": 922000,
+          "maxOutputTokens": 128000,
+          "structuredOutput": true,
+          "lastUpdated": "2026-09-04",
+          "capabilities": {
+            "vision": true,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-image-1": {
@@ -32281,8 +43648,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-1-mini": {
@@ -32298,8 +43669,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-1.5": {
@@ -32315,8 +43690,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-image-2": {
@@ -32332,8 +43711,54 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
+          }
+        },
+        "openai/gpt-image-2.5-flare": {
+          "displayName": "GPT Image 2.5 Flare",
+          "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+          "lifecycle": "active",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-09-08",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
+          }
+        },
+        "openai/gpt-image-2.5-sunburst": {
+          "displayName": "GPT Image 2.5 Sunburst",
+          "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+          "lifecycle": "active",
+          "contextWindow": 0,
+          "maxOutputTokens": 0,
+          "lastUpdated": "2026-09-08",
+          "capabilities": {
+            "vision": false,
+            "reasoning": false,
+            "functionCalling": false
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "openai/gpt-oss-120b": {
@@ -32351,11 +43776,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-20b": {
@@ -32374,11 +43807,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-120b": {
@@ -32396,11 +43837,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -32418,11 +43867,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-realtime-1.5": {
@@ -32438,8 +43895,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-2": {
@@ -32455,8 +43918,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-2.1": {
@@ -32475,11 +43944,23 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-mini": {
@@ -32495,8 +43976,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "openai/gpt-realtime-whisper": {
@@ -32512,8 +43999,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o1": {
@@ -32531,11 +44022,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3": {
@@ -32553,11 +44054,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-fast": {
@@ -32576,11 +44087,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-mini": {
@@ -32598,11 +44119,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o3-pro": {
@@ -32621,11 +44150,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini": {
@@ -32643,11 +44182,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/o4-mini-fast": {
@@ -32666,11 +44214,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-3-large": {
@@ -32687,8 +44245,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-3-small": {
@@ -32705,8 +44267,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/text-embedding-ada-002": {
@@ -32723,8 +44289,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/tts-1": {
@@ -32740,8 +44310,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "openai/tts-1-hd": {
@@ -32757,8 +44331,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "openai/whisper-1": {
@@ -32774,8 +44352,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/pplx-embed-v1-0.6b": {
@@ -32791,8 +44373,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/pplx-embed-v1-4b": {
@@ -32808,8 +44394,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar": {
@@ -32826,8 +44416,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-pro": {
@@ -32844,8 +44439,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -32862,11 +44462,21 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["minimal", "low", "medium", "high"]
+            "efforts": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -32886,8 +44496,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "poolside/laguna-s-2.1-free": {
@@ -32908,8 +44522,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "prodia/flux-fast-schnell": {
@@ -32925,8 +44543,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "quiverai/arrow-1.1": {
@@ -32942,8 +44564,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v2": {
@@ -32959,8 +44585,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v3": {
@@ -32976,8 +44606,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4": {
@@ -32993,8 +44627,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4-pro": {
@@ -33010,8 +44648,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1": {
@@ -33027,8 +44669,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-pro": {
@@ -33044,8 +44690,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-utility": {
@@ -33061,8 +44711,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "recraft/recraft-v4.1-utility-pro": {
@@ -33078,8 +44732,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "sakana/fugu-ultra": {
@@ -33096,8 +44754,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sakana/namazu": {
@@ -33113,8 +44776,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.1-fast-non-reasoning": {
@@ -33130,8 +44799,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.1-fast-reasoning": {
@@ -33147,8 +44822,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-multi-agent": {
@@ -33164,8 +44845,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-multi-agent-beta": {
@@ -33181,8 +44868,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-non-reasoning": {
@@ -33198,8 +44891,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-non-reasoning-beta": {
@@ -33215,8 +44914,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-reasoning": {
@@ -33232,8 +44937,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.20-reasoning-beta": {
@@ -33249,8 +44960,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.3": {
@@ -33267,11 +44984,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.5": {
@@ -33288,11 +45015,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-4.6": {
@@ -33310,11 +45047,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-build-0.1": {
@@ -33331,8 +45077,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-imagine-image": {
@@ -33348,8 +45099,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "spacexai/grok-imagine-image-2.0": {
@@ -33365,8 +45120,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["image"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "image"
+            ]
           }
         },
         "spacexai/grok-imagine-video": {
@@ -33382,8 +45141,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "spacexai/grok-imagine-video-1.5": {
@@ -33399,25 +45162,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["video"]
-          }
-        },
-        "spacexai/grok-imagine-video-1.5-preview": {
-          "displayName": "Grok Imagine Video 1.5 Preview",
-          "description": "Image model for prompt-driven generation, editing, and visual design workflows",
-          "lifecycle": "active",
-          "contextWindow": 0,
-          "maxOutputTokens": 0,
-          "lastUpdated": "2026-05-30",
-          "capabilities": {
-            "vision": false,
-            "reasoning": false,
-            "functionCalling": false
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["video"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "spacexai/grok-stt": {
@@ -33433,8 +45183,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["audio"],
-            "output": ["text"]
+            "input": [
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "spacexai/grok-tts": {
@@ -33450,8 +45204,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "spacexai/grok-voice-think-fast-1.0": {
@@ -33467,8 +45225,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "spacexai/grok-voice-think-fast-2.0": {
@@ -33484,8 +45248,14 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "audio"],
-            "output": ["text", "audio"]
+            "input": [
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text",
+              "audio"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -33502,11 +45272,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -33524,11 +45303,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-lite": {
@@ -33544,8 +45332,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-plus": {
@@ -33561,8 +45353,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy-mt2-pro": {
@@ -33578,8 +45374,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3": {
@@ -33595,11 +45395,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy4-preview": {
@@ -33615,11 +45423,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "high"]
+            "efforts": [
+              "none",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling": {
@@ -33635,11 +45450,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -33655,11 +45484,25 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/rerank-2.5": {
@@ -33675,8 +45518,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/rerank-2.5-lite": {
@@ -33692,8 +45539,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3-large": {
@@ -33709,8 +45560,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3.5": {
@@ -33726,8 +45581,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-3.5-lite": {
@@ -33743,8 +45602,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4": {
@@ -33760,8 +45623,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4-large": {
@@ -33777,8 +45644,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-4-lite": {
@@ -33794,8 +45665,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-code-2": {
@@ -33811,8 +45686,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-code-3": {
@@ -33828,8 +45707,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-finance-2": {
@@ -33845,8 +45728,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "voyage/voyage-law-2": {
@@ -33862,8 +45749,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -33883,8 +45774,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -33904,29 +45800,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
-          }
-        },
-        "xiaomi/mimo-v2.5-pro-ultraspeed": {
-          "displayName": "MiMo V2.5 Pro UltraSpeed",
-          "description": "MiMo pro model for strong multimodal reasoning and agent execution",
-          "lifecycle": "active",
-          "contextWindow": 1048576,
-          "maxOutputTokens": 131072,
-          "knowledgeCutoff": "2024-12",
-          "lastUpdated": "2026-06-09",
-          "capabilities": {
-            "vision": false,
-            "reasoning": true,
-            "functionCalling": true
-          },
-          "thinkingOptions": {
-            "toggle": true
-          },
-          "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5": {
@@ -33946,8 +45825,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5-air": {
@@ -33967,8 +45850,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.5v": {
@@ -33988,8 +45875,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.6": {
@@ -34009,8 +45901,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7": {
@@ -34030,8 +45926,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7-flash": {
@@ -34051,8 +45951,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-4.7-flashx": {
@@ -34072,8 +45976,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5": {
@@ -34092,8 +46000,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5-turbo": {
@@ -34113,8 +46025,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.1": {
@@ -34134,8 +46050,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.2": {
@@ -34152,12 +46072,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.2-fast": {
@@ -34174,12 +46101,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "xhigh"],
+            "efforts": [
+              "high",
+              "xhigh"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.3": {
@@ -34196,11 +46130,48 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "zai/glm-5.3-fast": {
+          "displayName": "GLM 5.3 Fast",
+          "description": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+          "lifecycle": "active",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 262144,
+          "structuredOutput": true,
+          "lastUpdated": "2026-08-14",
+          "capabilities": {
+            "vision": false,
+            "reasoning": true,
+            "functionCalling": true
+          },
+          "thinkingOptions": {
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5.3-flash": {
@@ -34217,11 +46188,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "zai/glm-5v-turbo": {
@@ -34240,8 +46220,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -34260,8 +46246,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.20-0309-reasoning": {
@@ -34278,8 +46270,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.20-multi-agent-0309": {
@@ -34296,11 +46294,22 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.3": {
@@ -34317,11 +46326,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.5": {
@@ -34338,11 +46358,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-4.6": {
@@ -34360,11 +46390,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high", "xhigh"]
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-build-0.1": {
@@ -34381,15 +46422,21 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "grok-imagine-image": {
           "displayName": "Grok Imagine Image",
           "description": "Image model for prompt-driven generation, editing, and visual design workflows",
           "lifecycle": "active",
-          "contextWindow": 8000,
+          "contextWindow": 16000,
           "maxOutputTokens": 0,
           "lastUpdated": "2026-01-28",
           "capabilities": {
@@ -34398,15 +46445,22 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image", "pdf"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "pdf"
+            ]
           }
         },
         "grok-imagine-image-2.0": {
           "displayName": "Grok Imagine Image 2.0",
           "description": "Image model for prompt-driven generation, editing, and visual design workflows",
           "lifecycle": "active",
-          "contextWindow": 8000,
+          "contextWindow": 64000,
           "maxOutputTokens": 0,
           "lastUpdated": "2026-08-07",
           "capabilities": {
@@ -34415,15 +46469,22 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image", "pdf"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "pdf"
+            ]
           }
         },
         "grok-imagine-image-quality": {
           "displayName": "Grok Imagine Image Quality",
           "description": "Image model for prompt-driven generation, editing, and visual design workflows",
           "lifecycle": "active",
-          "contextWindow": 8000,
+          "contextWindow": 16000,
           "maxOutputTokens": 0,
           "lastUpdated": "2026-04-03",
           "capabilities": {
@@ -34432,8 +46493,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["image", "pdf"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "image",
+              "pdf"
+            ]
           }
         },
         "grok-imagine-video": {
@@ -34449,8 +46517,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "video"
+            ]
           }
         },
         "grok-imagine-video-1.5": {
@@ -34466,8 +46541,15 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text", "image", "audio", "pdf"],
-            "output": ["video"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "video"
+            ]
           }
         }
       },
@@ -34489,8 +46571,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-omni": {
@@ -34510,8 +46596,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-pro": {
@@ -34531,8 +46625,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -34552,8 +46650,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -34573,8 +46678,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro-ultraspeed": {
@@ -34594,8 +46703,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -34618,8 +46731,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -34636,8 +46753,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -34658,8 +46779,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -34680,8 +46808,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -34698,8 +46830,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -34716,8 +46852,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -34734,8 +46874,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -34758,8 +46902,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -34776,8 +46924,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -34798,8 +46950,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -34820,8 +46979,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -34838,8 +47001,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -34856,8 +47023,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -34874,8 +47045,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -34898,8 +47073,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2-tts": {
@@ -34916,8 +47095,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5": {
@@ -34938,8 +47121,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-pro": {
@@ -34960,8 +47150,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "mimo-v2.5-tts": {
@@ -34978,8 +47172,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -34996,8 +47194,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -35014,8 +47216,12 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["audio"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "audio"
+            ]
           }
         }
       },
@@ -35037,8 +47243,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5-air": {
@@ -35058,8 +47268,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5-flash": {
@@ -35080,8 +47294,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.5v": {
@@ -35101,8 +47319,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6": {
@@ -35122,8 +47346,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.6v": {
@@ -35143,8 +47371,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7": {
@@ -35164,8 +47398,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-flash": {
@@ -35186,8 +47424,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-4.7-flashx": {
@@ -35207,8 +47449,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5": {
@@ -35227,8 +47473,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-turbo": {
@@ -35248,8 +47498,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.1": {
@@ -35269,8 +47523,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -35287,11 +47545,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -35308,11 +47573,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3-flash": {
@@ -35329,11 +47602,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5v-turbo": {
@@ -35352,8 +47636,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -35376,8 +47667,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5-turbo": {
@@ -35398,8 +47693,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2": {
@@ -35417,11 +47716,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.2-highspeed": {
@@ -35439,11 +47745,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3": {
@@ -35461,11 +47774,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3-flash": {
@@ -35483,11 +47804,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "glm-5.3-highspeed": {
@@ -35505,11 +47837,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "high", "max"]
+            "efforts": [
+              "low",
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       },
@@ -35528,8 +47868,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-3.7-sonnet": {
@@ -35546,11 +47891,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-fable-5": {
@@ -35567,11 +47922,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -35588,8 +47953,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4": {
@@ -35606,11 +47976,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -35627,11 +48007,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -35648,11 +48038,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -35669,11 +48069,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -35690,11 +48099,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -35711,11 +48130,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -35732,11 +48161,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -35753,11 +48192,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -35774,11 +48223,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -35795,11 +48253,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "anthropic/claude-sonnet-5-free": {
@@ -35817,11 +48285,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "baidu/ernie-5.0-thinking-preview": {
@@ -35838,8 +48316,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-chat": {
@@ -35856,8 +48340,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -35877,8 +48365,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -35898,8 +48390,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -35917,12 +48413,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -35940,12 +48444,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"],
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash": {
@@ -35962,11 +48474,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -35983,8 +48506,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-2.5-pro": {
@@ -36001,11 +48531,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["pdf", "image", "text", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -36022,11 +48564,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -36044,11 +48597,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -36064,8 +48629,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -36082,11 +48654,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "google/gemini-3.5-flash": {
@@ -36104,11 +48688,23 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video", "audio", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ling-1t": {
@@ -36125,8 +48721,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ring-1t": {
@@ -36143,8 +48743,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "inclusionai/ring-2.6-1t": {
@@ -36161,8 +48765,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "kuaishou/kat-coder-pro-v2": {
@@ -36178,8 +48786,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2": {
@@ -36196,8 +48808,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.1": {
@@ -36214,8 +48830,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5": {
@@ -36232,8 +48852,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.5-lightning": {
@@ -36250,8 +48874,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7": {
@@ -36268,8 +48896,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -36286,8 +48918,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "minimax/minimax-m3": {
@@ -36306,8 +48942,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -36324,8 +48966,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -36342,8 +48988,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2-thinking-turbo": {
@@ -36360,8 +49010,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -36381,8 +49035,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -36402,8 +49062,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -36421,8 +49087,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k2.7-code-free": {
@@ -36441,8 +49113,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3": {
@@ -36459,12 +49137,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"],
+            "efforts": [
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "moonshotai/kimi-k3-free": {
@@ -36482,12 +49168,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["max"],
+            "efforts": [
+              "max"
+            ],
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5": {
@@ -36504,11 +49198,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5-codex": {
@@ -36525,11 +49229,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1": {
@@ -36546,17 +49259,27 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-chat": {
           "displayName": "GPT-5.1 Chat",
           "description": "Chat-tuned GPT model for conversational assistance, writing, and tool workflows",
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "contextWindow": 128000,
           "maxOutputTokens": 64000,
           "knowledgeCutoff": "2025-01-01",
@@ -36567,8 +49290,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["pdf", "image", "text"],
-            "output": ["text"]
+            "input": [
+              "pdf",
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -36585,11 +49314,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -36606,11 +49344,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2": {
@@ -36627,11 +49374,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["image", "text", "pdf"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -36648,11 +49405,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -36669,11 +49436,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-chat": {
@@ -36690,8 +49467,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -36708,11 +49489,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4": {
@@ -36729,11 +49518,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -36750,8 +49548,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -36768,8 +49570,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -36786,11 +49592,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5": {
@@ -36809,11 +49624,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-instant": {
@@ -36832,11 +49657,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -36855,11 +49690,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["medium", "high", "xhigh"]
+            "efforts": [
+              "medium",
+              "high",
+              "xhigh"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -36878,11 +49723,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -36901,11 +49759,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -36924,11 +49795,24 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -36945,8 +49829,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3-max": {
@@ -36963,8 +49851,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-flash": {
@@ -36981,8 +49873,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.5-plus": {
@@ -36999,11 +49896,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -37022,8 +49928,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-max": {
@@ -37042,8 +49952,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -37063,8 +49977,14 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sapiens-ai/agnes-1.5-lite": {
@@ -37080,8 +50000,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "sapiens-ai/agnes-1.5-pro": {
@@ -37097,8 +50022,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3": {
@@ -37115,8 +50044,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -37133,8 +50067,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -37152,11 +50090,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "stepfun/step-3.7-flash-free": {
@@ -37175,11 +50123,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "tencent/hy3-preview": {
@@ -37195,11 +50153,19 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-1.8": {
@@ -37216,11 +50182,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-code": {
@@ -37237,8 +50213,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-lite": {
@@ -37255,11 +50235,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-mini": {
@@ -37276,11 +50266,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-2.0-pro": {
@@ -37297,11 +50297,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "volcengine/doubao-seed-code": {
@@ -37318,11 +50328,20 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4": {
@@ -37339,8 +50358,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["image", "text"],
-            "output": ["text"]
+            "input": [
+              "image",
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4-fast": {
@@ -37360,8 +50384,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.1-fast": {
@@ -37381,8 +50410,13 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.1-fast-non-reasoning": {
@@ -37399,8 +50433,13 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.2-fast": {
@@ -37417,8 +50456,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.2-fast-non-reasoning": {
@@ -37435,8 +50480,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.3": {
@@ -37453,11 +50504,22 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["none", "low", "medium", "high"]
+            "efforts": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-4.5": {
@@ -37474,11 +50536,21 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["low", "medium", "high"]
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -37495,8 +50567,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "x-ai/grok-code-fast-1": {
@@ -37513,8 +50591,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-flash": {
@@ -37534,8 +50616,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-omni": {
@@ -37555,8 +50641,16 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2-pro": {
@@ -37576,8 +50670,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -37597,8 +50695,15 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text", "image", "audio", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -37618,8 +50723,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5": {
@@ -37639,8 +50748,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -37660,8 +50773,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6": {
@@ -37678,8 +50795,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v": {
@@ -37696,8 +50817,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v-flash": {
@@ -37714,8 +50841,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.6v-flash-free": {
@@ -37733,8 +50866,14 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7": {
@@ -37751,8 +50890,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flash-free": {
@@ -37770,8 +50913,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-4.7-flashx": {
@@ -37788,8 +50935,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5": {
@@ -37806,8 +50957,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -37824,8 +50979,12 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.1": {
@@ -37845,8 +51004,12 @@
             "toggle": true
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2": {
@@ -37863,11 +51026,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5.2-free": {
@@ -37885,11 +51055,18 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": ["high", "max"]
+            "efforts": [
+              "high",
+              "max"
+            ]
           },
           "modalities": {
-            "input": ["text"],
-            "output": ["text"]
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -37905,8 +51082,15 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": ["text", "image", "video", "pdf"],
-            "output": ["text"]
+            "input": [
+              "text",
+              "image",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
           }
         }
       }
@@ -37917,6 +51101,13 @@
         "inputUsdPer1M": 10,
         "outputUsdPer1M": 50,
         "cacheReadUsdPer1M": 1,
+        "cacheWriteUsdPer1M": 12.5
+      },
+      {
+        "modelKey": "anthropic:claude-fable-5-1",
+        "inputUsdPer1M": 10,
+        "outputUsdPer1M": 50,
+        "cacheReadUsdPer1M": 0.25,
         "cacheWriteUsdPer1M": 12.5
       },
       {
@@ -38683,14 +51874,14 @@
         "outputUsdPer1M": 0.144
       },
       {
-        "modelKey": "cerebras:gemma-4-31b",
-        "inputUsdPer1M": 0.99,
-        "outputUsdPer1M": 1.49
-      },
-      {
         "modelKey": "cerebras:gpt-oss-120b",
         "inputUsdPer1M": 0.35,
         "outputUsdPer1M": 0.75
+      },
+      {
+        "modelKey": "cerebras:qwen-3.8-27b",
+        "inputUsdPer1M": 0.99,
+        "outputUsdPer1M": 1.49
       },
       {
         "modelKey": "cohere:command-a-03-2025",
@@ -38922,9 +52113,15 @@
       },
       {
         "modelKey": "deepinfra:deepseek-ai/DeepSeek-V4-Flash-0731",
-        "inputUsdPer1M": 0.08,
+        "inputUsdPer1M": 0.06,
         "outputUsdPer1M": 0.18,
-        "cacheReadUsdPer1M": 0.016
+        "cacheReadUsdPer1M": 0.015
+      },
+      {
+        "modelKey": "deepinfra:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+        "inputUsdPer1M": 0.44,
+        "outputUsdPer1M": 1.32,
+        "cacheReadUsdPer1M": 0.014
       },
       {
         "modelKey": "deepinfra:deepseek-ai/DeepSeek-V4-Pro",
@@ -38937,6 +52134,27 @@
         "inputUsdPer1M": 1.3,
         "outputUsdPer1M": 2.6,
         "cacheReadUsdPer1M": 0.1
+      },
+      {
+        "modelKey": "deepinfra:deepseek-ai/DeepSeek-V4.1-Flash",
+        "inputUsdPer1M": 0.2,
+        "outputUsdPer1M": 0.6,
+        "cacheReadUsdPer1M": 0.006
+      },
+      {
+        "modelKey": "deepinfra:google/gemma-3-12b-it",
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "deepinfra:google/gemma-3-27b-it",
+        "inputUsdPer1M": 0.08,
+        "outputUsdPer1M": 0.16
+      },
+      {
+        "modelKey": "deepinfra:google/gemma-3-4b-it",
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.1
       },
       {
         "modelKey": "deepinfra:google/gemma-4-26B-A4B-it",
@@ -39149,9 +52367,9 @@
       },
       {
         "modelKey": "deepinfra:XiaomiMiMo/MiMo-V2.5",
-        "inputUsdPer1M": 0.4,
-        "outputUsdPer1M": 2,
-        "cacheReadUsdPer1M": 0.08
+        "inputUsdPer1M": 0.14,
+        "outputUsdPer1M": 0.28,
+        "cacheReadUsdPer1M": 0.0028
       },
       {
         "modelKey": "deepinfra:XiaomiMiMo/MiMo-V2.5-Pro",
@@ -39208,16 +52426,22 @@
         "cacheReadUsdPer1M": 0.03
       },
       {
+        "modelKey": "deepseek:deepseek-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6,
+        "cacheReadUsdPer1M": 0.003
+      },
+      {
         "modelKey": "deepseek:deepseek-v4-flash",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.0028
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6,
+        "cacheReadUsdPer1M": 0.003
       },
       {
         "modelKey": "deepseek:deepseek-v4-flash-vision-exp",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.0028
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6,
+        "cacheReadUsdPer1M": 0.003
       },
       {
         "modelKey": "deepseek:deepseek-v4-pro",
@@ -39227,15 +52451,27 @@
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-flash-0731",
-        "inputUsdPer1M": 0.14,
-        "outputUsdPer1M": 0.28,
-        "cacheReadUsdPer1M": 0.028
+        "inputUsdPer1M": 0.22,
+        "outputUsdPer1M": 0.66,
+        "cacheReadUsdPer1M": 0.007
+      },
+      {
+        "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+        "inputUsdPer1M": 0.22,
+        "outputUsdPer1M": 0.66,
+        "cacheReadUsdPer1M": 0.007
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4-pro-0813",
         "inputUsdPer1M": 1.32,
         "outputUsdPer1M": 3.96,
         "cacheReadUsdPer1M": 0.044
+      },
+      {
+        "modelKey": "fireworks-ai:accounts/fireworks/models/deepseek-v4p1-flash",
+        "inputUsdPer1M": 0.22,
+        "outputUsdPer1M": 0.66,
+        "cacheReadUsdPer1M": 0.007
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/glm-5p2",
@@ -39253,7 +52489,7 @@
         "modelKey": "fireworks-ai:accounts/fireworks/models/glm-5p3-flash",
         "inputUsdPer1M": 0.15,
         "outputUsdPer1M": 0.5,
-        "cacheReadUsdPer1M": 0.029
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/models/gpt-oss-120b",
@@ -39316,6 +52552,12 @@
         "cacheReadUsdPer1M": 0.08
       },
       {
+        "modelKey": "fireworks-ai:accounts/fireworks/models/qwen3p8-2p4t-a95b",
+        "inputUsdPer1M": 2,
+        "outputUsdPer1M": 6,
+        "cacheReadUsdPer1M": 0.25
+      },
+      {
         "modelKey": "fireworks-ai:accounts/fireworks/models/qwen3p8-max",
         "inputUsdPer1M": 2,
         "outputUsdPer1M": 6,
@@ -39326,6 +52568,12 @@
         "inputUsdPer1M": 2.1,
         "outputUsdPer1M": 6.6,
         "cacheReadUsdPer1M": 0.21
+      },
+      {
+        "modelKey": "fireworks-ai:accounts/fireworks/routers/glm-5p3-fast",
+        "inputUsdPer1M": 2.1,
+        "outputUsdPer1M": 6.6,
+        "cacheReadUsdPer1M": 0.39
       },
       {
         "modelKey": "fireworks-ai:accounts/fireworks/routers/kimi-k3-fast",
@@ -39439,6 +52687,12 @@
       },
       {
         "modelKey": "google:gemini-3.7-flash",
+        "inputUsdPer1M": 0.75,
+        "outputUsdPer1M": 3.75,
+        "cacheReadUsdPer1M": 0.075
+      },
+      {
+        "modelKey": "google:gemini-3.8-flash",
         "inputUsdPer1M": 0.75,
         "outputUsdPer1M": 3.75,
         "cacheReadUsdPer1M": 0.075
@@ -39574,6 +52828,11 @@
         "outputUsdPer1M": 0.28
       },
       {
+        "modelKey": "huggingface:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+        "inputUsdPer1M": 0.44,
+        "outputUsdPer1M": 1.32
+      },
+      {
         "modelKey": "huggingface:deepseek-ai/DeepSeek-V4-Pro",
         "inputUsdPer1M": 0.435,
         "outputUsdPer1M": 0.87,
@@ -39583,6 +52842,26 @@
         "modelKey": "huggingface:deepseek-ai/DeepSeek-V4-Pro-0813",
         "inputUsdPer1M": 1.32,
         "outputUsdPer1M": 3.96
+      },
+      {
+        "modelKey": "huggingface:deepseek-ai/DeepSeek-V4.1-Flash",
+        "inputUsdPer1M": 0.3,
+        "outputUsdPer1M": 1.2
+      },
+      {
+        "modelKey": "huggingface:google/gemma-3-12b-it",
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "huggingface:google/gemma-3-27b-it",
+        "inputUsdPer1M": 0.08,
+        "outputUsdPer1M": 0.16
+      },
+      {
+        "modelKey": "huggingface:google/gemma-3-4b-it",
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.1
       },
       {
         "modelKey": "huggingface:google/gemma-4-26B-A4B-it",
@@ -40102,42 +53381,6 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.14
-      },
-      {
-        "modelKey": "moonshot:kimi-k2-0711-preview",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 2.5,
-        "cacheReadUsdPer1M": 0.15
-      },
-      {
-        "modelKey": "moonshot:kimi-k2-0905-preview",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 2.5,
-        "cacheReadUsdPer1M": 0.15
-      },
-      {
-        "modelKey": "moonshot:kimi-k2-thinking",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 2.5,
-        "cacheReadUsdPer1M": 0.15
-      },
-      {
-        "modelKey": "moonshot:kimi-k2-thinking-turbo",
-        "inputUsdPer1M": 1.15,
-        "outputUsdPer1M": 8,
-        "cacheReadUsdPer1M": 0.15
-      },
-      {
-        "modelKey": "moonshot:kimi-k2-turbo-preview",
-        "inputUsdPer1M": 2.4,
-        "outputUsdPer1M": 10,
-        "cacheReadUsdPer1M": 0.6
-      },
-      {
-        "modelKey": "moonshot:kimi-k2.5",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 3,
-        "cacheReadUsdPer1M": 0.1
       },
       {
         "modelKey": "moonshot:kimi-k2.6",
@@ -40903,6 +54146,13 @@
         "cacheWriteUsdPer1M": 12.5
       },
       {
+        "modelKey": "opencode:claude-fable-5-1",
+        "inputUsdPer1M": 10,
+        "outputUsdPer1M": 50,
+        "cacheReadUsdPer1M": 0.25,
+        "cacheWriteUsdPer1M": 12.5
+      },
+      {
         "modelKey": "opencode:claude-haiku-4-5",
         "inputUsdPer1M": 1,
         "outputUsdPer1M": 5,
@@ -40978,6 +54228,12 @@
         "cacheReadUsdPer1M": 0
       },
       {
+        "modelKey": "opencode:deepseek-v4-flash-vision-exp",
+        "inputUsdPer1M": 0.14,
+        "outputUsdPer1M": 0.28,
+        "cacheReadUsdPer1M": 0.028
+      },
+      {
         "modelKey": "opencode:deepseek-v4-pro",
         "inputUsdPer1M": 1.74,
         "outputUsdPer1M": 3.84,
@@ -41009,6 +54265,12 @@
       },
       {
         "modelKey": "opencode:gemini-3.7-flash",
+        "inputUsdPer1M": 1.5,
+        "outputUsdPer1M": 7.5,
+        "cacheReadUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "opencode:gemini-3.8-flash",
         "inputUsdPer1M": 1.5,
         "outputUsdPer1M": 7.5,
         "cacheReadUsdPer1M": 0.15
@@ -41054,6 +54316,18 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "opencode:glm-5.3",
+        "inputUsdPer1M": 1.4,
+        "outputUsdPer1M": 4.4,
+        "cacheReadUsdPer1M": 0.26
+      },
+      {
+        "modelKey": "opencode:glm-5.3-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.5,
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "opencode:gpt-5",
@@ -41325,6 +54599,18 @@
         "cacheReadUsdPer1M": 0
       },
       {
+        "modelKey": "opencode:muse-spark-1.3",
+        "inputUsdPer1M": 1.25,
+        "outputUsdPer1M": 4.25,
+        "cacheReadUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "opencode:muse-spark-1.3-contributor-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0,
+        "cacheReadUsdPer1M": 0
+      },
+      {
         "modelKey": "opencode:nemotron-3-super-free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0,
@@ -41392,7 +54678,7 @@
         "modelKey": "openrouter:~anthropic/claude-fable-latest",
         "inputUsdPer1M": 10,
         "outputUsdPer1M": 50,
-        "cacheReadUsdPer1M": 1,
+        "cacheReadUsdPer1M": 0.25,
         "cacheWriteUsdPer1M": 12.5
       },
       {
@@ -41418,9 +54704,9 @@
       },
       {
         "modelKey": "openrouter:~deepseek/deepseek-v4-flash-latest",
-        "inputUsdPer1M": 0.05,
-        "outputUsdPer1M": 0.16,
-        "cacheReadUsdPer1M": 0.013
+        "inputUsdPer1M": 0.03,
+        "outputUsdPer1M": 0.07,
+        "cacheReadUsdPer1M": 0.003
       },
       {
         "modelKey": "openrouter:~google/gemini-flash-latest",
@@ -41431,9 +54717,9 @@
       },
       {
         "modelKey": "openrouter:~moonshotai/kimi-latest",
-        "inputUsdPer1M": 2.55,
-        "outputUsdPer1M": 12.75,
-        "cacheReadUsdPer1M": 0.256
+        "inputUsdPer1M": 2.125,
+        "outputUsdPer1M": 11.9,
+        "cacheReadUsdPer1M": 0.2465
       },
       {
         "modelKey": "openrouter:~openai/gpt-mini-latest",
@@ -41442,10 +54728,16 @@
         "cacheReadUsdPer1M": 0.075
       },
       {
+        "modelKey": "openrouter:~z-ai/glm-flash-latest",
+        "inputUsdPer1M": 0.075,
+        "outputUsdPer1M": 0.25,
+        "cacheReadUsdPer1M": 0.015
+      },
+      {
         "modelKey": "openrouter:~z-ai/glm-latest",
-        "inputUsdPer1M": 1.17,
-        "outputUsdPer1M": 3.96,
-        "cacheReadUsdPer1M": 0.234
+        "inputUsdPer1M": 0.8727,
+        "outputUsdPer1M": 3.36,
+        "cacheReadUsdPer1M": 0.1639
       },
       {
         "modelKey": "openrouter:aion-labs/aion-2.0",
@@ -41516,6 +54808,13 @@
         "cacheWriteUsdPer1M": 12.5
       },
       {
+        "modelKey": "openrouter:anthropic/claude-fable-5.1",
+        "inputUsdPer1M": 10,
+        "outputUsdPer1M": 50,
+        "cacheReadUsdPer1M": 0.25,
+        "cacheWriteUsdPer1M": 12.5
+      },
+      {
         "modelKey": "openrouter:anthropic/claude-haiku-4.5",
         "inputUsdPer1M": 1,
         "outputUsdPer1M": 5,
@@ -41544,13 +54843,6 @@
         "cacheWriteUsdPer1M": 6.25
       },
       {
-        "modelKey": "openrouter:anthropic/claude-opus-4.7-fast",
-        "inputUsdPer1M": 30,
-        "outputUsdPer1M": 150,
-        "cacheReadUsdPer1M": 3,
-        "cacheWriteUsdPer1M": 37.5
-      },
-      {
         "modelKey": "openrouter:anthropic/claude-opus-4.8",
         "inputUsdPer1M": 5,
         "outputUsdPer1M": 25,
@@ -41558,25 +54850,11 @@
         "cacheWriteUsdPer1M": 6.25
       },
       {
-        "modelKey": "openrouter:anthropic/claude-opus-4.8-fast",
-        "inputUsdPer1M": 10,
-        "outputUsdPer1M": 50,
-        "cacheReadUsdPer1M": 1,
-        "cacheWriteUsdPer1M": 12.5
-      },
-      {
         "modelKey": "openrouter:anthropic/claude-opus-5",
         "inputUsdPer1M": 5,
         "outputUsdPer1M": 25,
         "cacheReadUsdPer1M": 0.5,
         "cacheWriteUsdPer1M": 6.25
-      },
-      {
-        "modelKey": "openrouter:anthropic/claude-opus-5-fast",
-        "inputUsdPer1M": 10,
-        "outputUsdPer1M": 50,
-        "cacheReadUsdPer1M": 1,
-        "cacheWriteUsdPer1M": 12.5
       },
       {
         "modelKey": "openrouter:anthropic/claude-sonnet-5",
@@ -41649,9 +54927,9 @@
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-chat-v3.1",
-        "inputUsdPer1M": 0.55,
-        "outputUsdPer1M": 1.65,
-        "cacheReadUsdPer1M": 0.55
+        "inputUsdPer1M": 0.25,
+        "outputUsdPer1M": 0.95,
+        "cacheReadUsdPer1M": 0.13
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-r1",
@@ -41688,33 +54966,39 @@
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-flash",
-        "inputUsdPer1M": 0.08092,
-        "outputUsdPer1M": 0.16184,
-        "cacheReadUsdPer1M": 0.016184
+        "inputUsdPer1M": 0.0665,
+        "outputUsdPer1M": 0.133,
+        "cacheReadUsdPer1M": 0.0133
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-flash-0731",
-        "inputUsdPer1M": 0.065,
-        "outputUsdPer1M": 0.18,
-        "cacheReadUsdPer1M": 0.016
+        "inputUsdPer1M": 0.04,
+        "outputUsdPer1M": 0.08,
+        "cacheReadUsdPer1M": 0.008
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-flash-vision-exp",
-        "inputUsdPer1M": 0.44,
-        "outputUsdPer1M": 1.32,
-        "cacheReadUsdPer1M": 0.014
+        "inputUsdPer1M": 0.22,
+        "outputUsdPer1M": 0.66,
+        "cacheReadUsdPer1M": 0.007
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-pro",
-        "inputUsdPer1M": 1.6,
-        "outputUsdPer1M": 3.2,
-        "cacheReadUsdPer1M": 0.135
+        "inputUsdPer1M": 0.768732,
+        "outputUsdPer1M": 1.537464,
+        "cacheReadUsdPer1M": 0.064061
       },
       {
         "modelKey": "openrouter:deepseek/deepseek-v4-pro-0813",
-        "inputUsdPer1M": 1.1154,
-        "outputUsdPer1M": 3.3462,
-        "cacheReadUsdPer1M": 0.03718
+        "inputUsdPer1M": 0.57816,
+        "outputUsdPer1M": 1.73448,
+        "cacheReadUsdPer1M": 0.018396
+      },
+      {
+        "modelKey": "openrouter:deepseek/deepseek-v4.1-flash",
+        "inputUsdPer1M": 0.15,
+        "outputUsdPer1M": 0.6,
+        "cacheReadUsdPer1M": 0.003
       },
       {
         "modelKey": "openrouter:dots-studio/dots-3-note-preview:free",
@@ -41821,6 +55105,13 @@
         "cacheWriteUsdPer1M": 0.041667
       },
       {
+        "modelKey": "openrouter:google/gemini-3.8-flash",
+        "inputUsdPer1M": 0.75,
+        "outputUsdPer1M": 3.75,
+        "cacheReadUsdPer1M": 0.075,
+        "cacheWriteUsdPer1M": 0.041667
+      },
+      {
         "modelKey": "openrouter:google/gemma-2-27b-it",
         "inputUsdPer1M": 0.65,
         "outputUsdPer1M": 0.65
@@ -41843,8 +55134,8 @@
       },
       {
         "modelKey": "openrouter:google/gemma-4-26b-a4b-it",
-        "inputUsdPer1M": 0.07,
-        "outputUsdPer1M": 0.34
+        "inputUsdPer1M": 0.042,
+        "outputUsdPer1M": 0.22
       },
       {
         "modelKey": "openrouter:google/gemma-4-26b-a4b-it:free",
@@ -41883,16 +55174,10 @@
         "outputUsdPer1M": 0.112
       },
       {
-        "modelKey": "openrouter:ibm-granite/granite-4.1-8b",
-        "inputUsdPer1M": 0.05,
-        "outputUsdPer1M": 0.1,
-        "cacheReadUsdPer1M": 0.05
-      },
-      {
         "modelKey": "openrouter:ibm-granite/granite-4.2-8b",
-        "inputUsdPer1M": 0.1,
-        "outputUsdPer1M": 0.15,
-        "cacheReadUsdPer1M": 0.05
+        "inputUsdPer1M": 0.06,
+        "outputUsdPer1M": 0.25,
+        "cacheReadUsdPer1M": 0.015
       },
       {
         "modelKey": "openrouter:inception/mercury-2",
@@ -41901,15 +55186,53 @@
         "cacheReadUsdPer1M": 0.025
       },
       {
+        "modelKey": "openrouter:inception/mercury-2.5",
+        "inputUsdPer1M": 0.04,
+        "outputUsdPer1M": 0.15,
+        "cacheReadUsdPer1M": 0.004
+      },
+      {
         "modelKey": "openrouter:inclusionai/ling-3.0-flash",
         "inputUsdPer1M": 0.021,
         "outputUsdPer1M": 0.063,
         "cacheReadUsdPer1M": 0.0042
       },
       {
+        "modelKey": "openrouter:inclusionai/ling-3.0-flash-fin",
+        "inputUsdPer1M": 0.06,
+        "outputUsdPer1M": 0.18,
+        "cacheReadUsdPer1M": 0.012
+      },
+      {
         "modelKey": "openrouter:inclusionai/ling-3.0-flash-fin:free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "openrouter:inclusionai/ling-3.0-flash-sante:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "openrouter:inclusionai/ling-3.0-flash-vl",
+        "inputUsdPer1M": 0.06,
+        "outputUsdPer1M": 0.18,
+        "cacheReadUsdPer1M": 0.012
+      },
+      {
+        "modelKey": "openrouter:inclusionai/ling-3.0-flash-vl:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "openrouter:inference-net/schematron-v2-small",
+        "inputUsdPer1M": 0.05,
+        "outputUsdPer1M": 0.23
+      },
+      {
+        "modelKey": "openrouter:inference-net/schematron-v2-turbo",
+        "inputUsdPer1M": 0.03,
+        "outputUsdPer1M": 0.15
       },
       {
         "modelKey": "openrouter:kwaipilot/kat-coder-pro-v2",
@@ -41941,8 +55264,8 @@
       },
       {
         "modelKey": "openrouter:meta-llama/llama-3.1-70b-instruct",
-        "inputUsdPer1M": 0.4,
-        "outputUsdPer1M": 0.4
+        "inputUsdPer1M": 0.72,
+        "outputUsdPer1M": 0.72
       },
       {
         "modelKey": "openrouter:meta-llama/llama-3.1-8b-instruct",
@@ -41962,9 +55285,8 @@
       },
       {
         "modelKey": "openrouter:meta-llama/llama-3.3-70b-instruct",
-        "inputUsdPer1M": 0.71,
-        "outputUsdPer1M": 0.71,
-        "cacheReadUsdPer1M": 0.71
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.32
       },
       {
         "modelKey": "openrouter:meta-llama/llama-4-maverick",
@@ -41984,7 +55306,7 @@
       {
         "modelKey": "openrouter:meta/muse-glimmer-30b",
         "inputUsdPer1M": 0.3,
-        "outputUsdPer1M": 1.2,
+        "outputUsdPer1M": 1.1,
         "cacheReadUsdPer1M": 0.04
       },
       {
@@ -42001,6 +55323,18 @@
       },
       {
         "modelKey": "openrouter:meta/muse-spark-1.2-contributor",
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.2,
+        "cacheReadUsdPer1M": 0.002
+      },
+      {
+        "modelKey": "openrouter:meta/muse-spark-1.3",
+        "inputUsdPer1M": 1.25,
+        "outputUsdPer1M": 4.25,
+        "cacheReadUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "openrouter:meta/muse-spark-1.3-contributor",
         "inputUsdPer1M": 0.1,
         "outputUsdPer1M": 0.2,
         "cacheReadUsdPer1M": 0.002
@@ -42055,20 +55389,10 @@
         "cacheReadUsdPer1M": 0.06
       },
       {
-        "modelKey": "openrouter:minimax/minimax-m2.7:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
-      },
-      {
         "modelKey": "openrouter:minimax/minimax-m3",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.06
-      },
-      {
-        "modelKey": "openrouter:minimax/minimax-m3:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
       },
       {
         "modelKey": "openrouter:mistralai/codestral-2508",
@@ -42192,8 +55516,7 @@
       {
         "modelKey": "openrouter:moonshotai/kimi-k2-thinking",
         "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 2.5,
-        "cacheReadUsdPer1M": 0.15
+        "outputUsdPer1M": 2.5
       },
       {
         "modelKey": "openrouter:moonshotai/kimi-k2.5",
@@ -42209,15 +55532,15 @@
       },
       {
         "modelKey": "openrouter:moonshotai/kimi-k2.7-code",
-        "inputUsdPer1M": 0.66,
-        "outputUsdPer1M": 3.4,
-        "cacheReadUsdPer1M": 0.18
+        "inputUsdPer1M": 0.71,
+        "outputUsdPer1M": 3.5,
+        "cacheReadUsdPer1M": 0.15
       },
       {
         "modelKey": "openrouter:moonshotai/kimi-k3",
-        "inputUsdPer1M": 3,
-        "outputUsdPer1M": 15,
-        "cacheReadUsdPer1M": 0.3
+        "inputUsdPer1M": 2.302729,
+        "outputUsdPer1M": 11.550195,
+        "cacheReadUsdPer1M": 0.263169
       },
       {
         "modelKey": "openrouter:morph/morph-v3-fast",
@@ -42230,16 +55553,14 @@
         "outputUsdPer1M": 1.9
       },
       {
-        "modelKey": "openrouter:nex-agi/nex-n2-mini",
-        "inputUsdPer1M": 0.025,
-        "outputUsdPer1M": 0.1,
-        "cacheReadUsdPer1M": 0.0025
+        "modelKey": "openrouter:nex-agi/nex-n2.5-mini:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
-        "modelKey": "openrouter:nex-agi/nex-n2-pro",
-        "inputUsdPer1M": 0.25,
-        "outputUsdPer1M": 1,
-        "cacheReadUsdPer1M": 0.025
+        "modelKey": "openrouter:nex-agi/nex-n2.5-pro:free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
       },
       {
         "modelKey": "openrouter:nousresearch/hermes-3-llama-3.1-405b",
@@ -42257,15 +55578,10 @@
         "outputUsdPer1M": 3
       },
       {
-        "modelKey": "openrouter:nousresearch/hermes-4-70b",
-        "inputUsdPer1M": 0.13,
-        "outputUsdPer1M": 0.4
-      },
-      {
         "modelKey": "openrouter:nvidia/nemotron-3-nano-30b-a3b",
         "inputUsdPer1M": 0.05,
         "outputUsdPer1M": 0.2,
-        "cacheReadUsdPer1M": 0.025
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
@@ -42284,14 +55600,19 @@
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-ultra-550b-a55b",
-        "inputUsdPer1M": 0.5,
-        "outputUsdPer1M": 2.2,
-        "cacheReadUsdPer1M": 0.1
+        "inputUsdPer1M": 0.625,
+        "outputUsdPer1M": 3.125,
+        "cacheReadUsdPer1M": 0.1875
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3-ultra-550b-a55b:free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "openrouter:nvidia/nemotron-3.5-content-safety",
+        "inputUsdPer1M": 0.2,
+        "outputUsdPer1M": 0.2
       },
       {
         "modelKey": "openrouter:nvidia/nemotron-3.5-content-safety:free",
@@ -42656,13 +55977,14 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen2.5-vl-72b-instruct",
-        "inputUsdPer1M": 0.25,
-        "outputUsdPer1M": 0.75
+        "inputUsdPer1M": 0.8,
+        "outputUsdPer1M": 1,
+        "cacheReadUsdPer1M": 0.4
       },
       {
         "modelKey": "openrouter:qwen/qwen3-14b",
-        "inputUsdPer1M": 0.12,
-        "outputUsdPer1M": 0.24
+        "inputUsdPer1M": 0.2275,
+        "outputUsdPer1M": 0.91
       },
       {
         "modelKey": "openrouter:qwen/qwen3-235b-a22b",
@@ -42687,8 +56009,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-30b-a3b-instruct-2507",
-        "inputUsdPer1M": 0.04815,
-        "outputUsdPer1M": 0.19305
+        "inputUsdPer1M": 0.09,
+        "outputUsdPer1M": 0.3
       },
       {
         "modelKey": "openrouter:qwen/qwen3-30b-a3b-thinking-2507",
@@ -42724,9 +56046,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3-next-80b-a3b-instruct",
-        "inputUsdPer1M": 0.1,
-        "outputUsdPer1M": 1.1,
-        "cacheReadUsdPer1M": 0.07
+        "inputUsdPer1M": 0.09,
+        "outputUsdPer1M": 1.1
       },
       {
         "modelKey": "openrouter:qwen/qwen3-next-80b-a3b-thinking",
@@ -42771,8 +56092,8 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-122b-a10b",
-        "inputUsdPer1M": 0.29,
-        "outputUsdPer1M": 2.4
+        "inputUsdPer1M": 0.26,
+        "outputUsdPer1M": 2.08
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-27b",
@@ -42781,14 +56102,15 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-35b-a3b",
-        "inputUsdPer1M": 0.25,
+        "inputUsdPer1M": 0.3125,
         "outputUsdPer1M": 1.25,
-        "cacheReadUsdPer1M": 0.25
+        "cacheReadUsdPer1M": 0.15625
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-397b-a17b",
-        "inputUsdPer1M": 0.39,
-        "outputUsdPer1M": 2.34
+        "inputUsdPer1M": 0.55,
+        "outputUsdPer1M": 3.5,
+        "cacheReadUsdPer1M": 0.225
       },
       {
         "modelKey": "openrouter:qwen/qwen3.5-9b",
@@ -42802,9 +56124,9 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.6-27b",
-        "inputUsdPer1M": 0.6,
-        "outputUsdPer1M": 3.6,
-        "cacheReadUsdPer1M": 0.12
+        "inputUsdPer1M": 0.3,
+        "outputUsdPer1M": 2,
+        "cacheReadUsdPer1M": 0.03
       },
       {
         "modelKey": "openrouter:qwen/qwen3.6-35b-a3b",
@@ -42827,10 +56149,9 @@
       },
       {
         "modelKey": "openrouter:qwen/qwen3.8-27b",
-        "inputUsdPer1M": 0.425,
+        "inputUsdPer1M": 0.214,
         "outputUsdPer1M": 2.55,
-        "cacheReadUsdPer1M": 0.085,
-        "cacheWriteUsdPer1M": 0.53125
+        "cacheReadUsdPer1M": 0.15
       },
       {
         "modelKey": "openrouter:qwen/qwen3.8-flash",
@@ -42840,7 +56161,7 @@
         "cacheWriteUsdPer1M": 0.2
       },
       {
-        "modelKey": "openrouter:qwen/qwen3.8-max",
+        "modelKey": "openrouter:qwen/qwen3.8-max-0902",
         "inputUsdPer1M": 2,
         "outputUsdPer1M": 6,
         "cacheReadUsdPer1M": 0.25,
@@ -42865,6 +56186,12 @@
         "modelKey": "openrouter:relace/relace-search",
         "inputUsdPer1M": 1,
         "outputUsdPer1M": 3
+      },
+      {
+        "modelKey": "openrouter:sakana/fugu-max",
+        "inputUsdPer1M": 2,
+        "outputUsdPer1M": 6,
+        "cacheReadUsdPer1M": 0.25
       },
       {
         "modelKey": "openrouter:sakana/sakana-namazu",
@@ -42977,7 +56304,7 @@
       },
       {
         "modelKey": "openrouter:undi95/remm-slerp-l2-13b",
-        "inputUsdPer1M": 0.45,
+        "inputUsdPer1M": 0.35,
         "outputUsdPer1M": 0.65
       },
       {
@@ -42988,9 +56315,9 @@
       },
       {
         "modelKey": "openrouter:upstage/solar-pro4",
-        "inputUsdPer1M": 0.03,
-        "outputUsdPer1M": 0.12,
-        "cacheReadUsdPer1M": 0.006
+        "inputUsdPer1M": 0.09,
+        "outputUsdPer1M": 0.36,
+        "cacheReadUsdPer1M": 0.018
       },
       {
         "modelKey": "openrouter:writer/palmyra-x5",
@@ -43047,9 +56374,8 @@
       },
       {
         "modelKey": "openrouter:z-ai/glm-4.7-flash",
-        "inputUsdPer1M": 0.06,
-        "outputUsdPer1M": 0.4,
-        "cacheReadUsdPer1M": 0.01
+        "inputUsdPer1M": 0.0605,
+        "outputUsdPer1M": 0.4
       },
       {
         "modelKey": "openrouter:z-ai/glm-5",
@@ -43071,14 +56397,9 @@
       },
       {
         "modelKey": "openrouter:z-ai/glm-5.2",
-        "inputUsdPer1M": 1.19,
-        "outputUsdPer1M": 3.74,
-        "cacheReadUsdPer1M": 0.221
-      },
-      {
-        "modelKey": "openrouter:z-ai/glm-5.2:free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
+        "inputUsdPer1M": 0.6,
+        "outputUsdPer1M": 2,
+        "cacheReadUsdPer1M": 0.15
       },
       {
         "modelKey": "openrouter:z-ai/glm-5.3",
@@ -43821,6 +57142,13 @@
         "cacheWriteUsdPer1M": 2.5
       },
       {
+        "modelKey": "vercel:alibaba/qwen3.8-max-0902",
+        "inputUsdPer1M": 2,
+        "outputUsdPer1M": 6,
+        "cacheReadUsdPer1M": 0.25,
+        "cacheWriteUsdPer1M": 2.5
+      },
+      {
         "modelKey": "vercel:amazon/nova-2-lite",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 2.5,
@@ -43830,19 +57158,22 @@
         "modelKey": "vercel:amazon/nova-lite",
         "inputUsdPer1M": 0.06,
         "outputUsdPer1M": 0.24,
-        "cacheReadUsdPer1M": 0.015
+        "cacheReadUsdPer1M": 0.015,
+        "cacheWriteUsdPer1M": 0.06
       },
       {
         "modelKey": "vercel:amazon/nova-micro",
         "inputUsdPer1M": 0.035,
         "outputUsdPer1M": 0.14,
-        "cacheReadUsdPer1M": 0.00875
+        "cacheReadUsdPer1M": 0.00875,
+        "cacheWriteUsdPer1M": 0.035
       },
       {
         "modelKey": "vercel:amazon/nova-pro",
         "inputUsdPer1M": 0.8,
         "outputUsdPer1M": 3.2,
-        "cacheReadUsdPer1M": 0.2
+        "cacheReadUsdPer1M": 0.2,
+        "cacheWriteUsdPer1M": 0.8
       },
       {
         "modelKey": "vercel:anthropic/claude-3-haiku",
@@ -43856,6 +57187,13 @@
         "inputUsdPer1M": 10,
         "outputUsdPer1M": 50,
         "cacheReadUsdPer1M": 1,
+        "cacheWriteUsdPer1M": 12.5
+      },
+      {
+        "modelKey": "vercel:anthropic/claude-fable-5.1",
+        "inputUsdPer1M": 10,
+        "outputUsdPer1M": 50,
+        "cacheReadUsdPer1M": 0.25,
         "cacheWriteUsdPer1M": 12.5
       },
       {
@@ -43970,12 +57308,6 @@
         "outputUsdPer1M": 5.4
       },
       {
-        "modelKey": "vercel:deepseek/deepseek-v3",
-        "inputUsdPer1M": 0.27,
-        "outputUsdPer1M": 1.12,
-        "cacheReadUsdPer1M": 0.135
-      },
-      {
         "modelKey": "vercel:deepseek/deepseek-v3.1",
         "inputUsdPer1M": 0.25,
         "outputUsdPer1M": 0.95,
@@ -43989,9 +57321,8 @@
       },
       {
         "modelKey": "vercel:deepseek/deepseek-v3.2",
-        "inputUsdPer1M": 0.28,
-        "outputUsdPer1M": 0.42,
-        "cacheReadUsdPer1M": 0.028
+        "inputUsdPer1M": 0.62,
+        "outputUsdPer1M": 1.85
       },
       {
         "modelKey": "vercel:deepseek/deepseek-v3.2-thinking",
@@ -44027,6 +57358,12 @@
         "inputUsdPer1M": 0.66,
         "outputUsdPer1M": 1.98,
         "cacheReadUsdPer1M": 0.066
+      },
+      {
+        "modelKey": "vercel:deepseek/deepseek-v4.1-flash",
+        "inputUsdPer1M": 0.3,
+        "outputUsdPer1M": 1.2,
+        "cacheReadUsdPer1M": 0.006
       },
       {
         "modelKey": "vercel:google/gemini-2.5-flash",
@@ -44118,6 +57455,12 @@
         "cacheReadUsdPer1M": 0.075
       },
       {
+        "modelKey": "vercel:google/gemini-3.8-flash",
+        "inputUsdPer1M": 0.75,
+        "outputUsdPer1M": 3.75,
+        "cacheReadUsdPer1M": 0.075
+      },
+      {
         "modelKey": "vercel:google/gemini-omni-flash-preview",
         "inputUsdPer1M": 1.5,
         "outputUsdPer1M": 9
@@ -44140,6 +57483,12 @@
         "cacheReadUsdPer1M": 0.024999999999999998
       },
       {
+        "modelKey": "vercel:inception/mercury-2.5",
+        "inputUsdPer1M": 0.04,
+        "outputUsdPer1M": 0.15,
+        "cacheReadUsdPer1M": 0.004
+      },
+      {
         "modelKey": "vercel:inception/mercury-coder-small",
         "inputUsdPer1M": 0.25,
         "outputUsdPer1M": 1
@@ -44157,6 +57506,16 @@
       },
       {
         "modelKey": "vercel:inclusionai/ling-3.0-flash-fin-free",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "vercel:inclusionai/ling-3.0-flash-sante",
+        "inputUsdPer1M": 0,
+        "outputUsdPer1M": 0
+      },
+      {
+        "modelKey": "vercel:inclusionai/ling-3.0-flash-sante-free",
         "inputUsdPer1M": 0,
         "outputUsdPer1M": 0
       },
@@ -44239,6 +57598,18 @@
         "cacheReadUsdPer1M": 0.002
       },
       {
+        "modelKey": "vercel:meta/muse-spark-1.3",
+        "inputUsdPer1M": 1.25,
+        "outputUsdPer1M": 4.25,
+        "cacheReadUsdPer1M": 0.15
+      },
+      {
+        "modelKey": "vercel:meta/muse-spark-1.3-contributor",
+        "inputUsdPer1M": 0.1,
+        "outputUsdPer1M": 0.2,
+        "cacheReadUsdPer1M": 0.002
+      },
+      {
         "modelKey": "vercel:minimax/minimax-m2",
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.2,
@@ -44281,11 +57652,6 @@
         "cacheWriteUsdPer1M": 0.375
       },
       {
-        "modelKey": "vercel:minimax/minimax-m2.7-free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0
-      },
-      {
         "modelKey": "vercel:minimax/minimax-m2.7-highspeed",
         "inputUsdPer1M": 0.6,
         "outputUsdPer1M": 2.4,
@@ -44297,12 +57663,6 @@
         "inputUsdPer1M": 0.3,
         "outputUsdPer1M": 1.2,
         "cacheReadUsdPer1M": 0.06
-      },
-      {
-        "modelKey": "vercel:minimax/minimax-m3-free",
-        "inputUsdPer1M": 0,
-        "outputUsdPer1M": 0,
-        "cacheReadUsdPer1M": 0
       },
       {
         "modelKey": "vercel:mistral/codestral",
@@ -44703,7 +58063,7 @@
         "inputUsdPer1M": 0.4,
         "outputUsdPer1M": 2.4,
         "cacheReadUsdPer1M": 0.04,
-        "cacheWriteUsdPer1M": 0.25
+        "cacheWriteUsdPer1M": 0.5
       },
       {
         "modelKey": "vercel:openai/gpt-5.6-sol",
@@ -44717,7 +58077,7 @@
         "inputUsdPer1M": 4,
         "outputUsdPer1M": 20,
         "cacheReadUsdPer1M": 0.4,
-        "cacheWriteUsdPer1M": 2.5
+        "cacheWriteUsdPer1M": 5
       },
       {
         "modelKey": "vercel:openai/gpt-5.6-terra",
@@ -44731,7 +58091,7 @@
         "inputUsdPer1M": 4,
         "outputUsdPer1M": 24,
         "cacheReadUsdPer1M": 0.4,
-        "cacheWriteUsdPer1M": 2.5
+        "cacheWriteUsdPer1M": 5
       },
       {
         "modelKey": "vercel:openai/gpt-image-1",
@@ -44753,6 +58113,18 @@
       },
       {
         "modelKey": "vercel:openai/gpt-image-2",
+        "inputUsdPer1M": 5,
+        "outputUsdPer1M": 30,
+        "cacheReadUsdPer1M": 1.25
+      },
+      {
+        "modelKey": "vercel:openai/gpt-image-2.5-flare",
+        "inputUsdPer1M": 5,
+        "outputUsdPer1M": 30,
+        "cacheReadUsdPer1M": 1.25
+      },
+      {
+        "modelKey": "vercel:openai/gpt-image-2.5-sunburst",
         "inputUsdPer1M": 5,
         "outputUsdPer1M": 30,
         "cacheReadUsdPer1M": 1.25
@@ -45001,12 +58373,6 @@
         "cacheReadUsdPer1M": 0.0036
       },
       {
-        "modelKey": "vercel:xiaomi/mimo-v2.5-pro-ultraspeed",
-        "inputUsdPer1M": 1.305,
-        "outputUsdPer1M": 2.61,
-        "cacheReadUsdPer1M": 0.0108
-      },
-      {
         "modelKey": "vercel:zai/glm-4.5",
         "inputUsdPer1M": 0.6,
         "outputUsdPer1M": 2.2,
@@ -45081,6 +58447,12 @@
         "inputUsdPer1M": 1.4,
         "outputUsdPer1M": 4.4,
         "cacheReadUsdPer1M": 0.14
+      },
+      {
+        "modelKey": "vercel:zai/glm-5.3-fast",
+        "inputUsdPer1M": 2.1,
+        "outputUsdPer1M": 6.6,
+        "cacheReadUsdPer1M": 0.21
       },
       {
         "modelKey": "vercel:zai/glm-5.3-flash",
@@ -45990,7 +59362,7 @@
         "id": "kimi-for-coding",
         "name": "Kimi For Coding",
         "api": "https://api.kimi.com/coding/v1",
-        "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html"
+        "doc": "https://www.kimi.com/code/docs/en/kimi-code/models.html"
       },
       "MiniMax": {
         "id": "minimax",
@@ -46201,6 +59573,9 @@
         "claude-fable-5": {
           "npm": "@ai-sdk/anthropic"
         },
+        "claude-fable-5-1": {
+          "npm": "@ai-sdk/anthropic"
+        },
         "claude-haiku-4-5": {
           "npm": "@ai-sdk/anthropic"
         },
@@ -46253,6 +59628,9 @@
           "npm": "@ai-sdk/google"
         },
         "gemini-3.7-flash": {
+          "npm": "@ai-sdk/google"
+        },
+        "gemini-3.8-flash": {
           "npm": "@ai-sdk/google"
         },
         "gpt-5": {
@@ -46315,6 +59693,9 @@
         "gpt-5.6-terra": {
           "npm": "@ai-sdk/openai"
         },
+        "gpt-6-astra": {
+          "npm": "@ai-sdk/openai"
+        },
         "grok-4.5": {
           "npm": "@ai-sdk/openai"
         },
@@ -46337,6 +59718,12 @@
           "npm": "@ai-sdk/openai"
         },
         "muse-spark-1.2-contributor-free": {
+          "npm": "@ai-sdk/openai"
+        },
+        "muse-spark-1.3": {
+          "npm": "@ai-sdk/openai"
+        },
+        "muse-spark-1.3-contributor-free": {
           "npm": "@ai-sdk/openai"
         },
         "qwen3.5-plus": {
@@ -46369,6 +59756,9 @@
           "npm": "@ai-sdk/anthropic"
         },
         "muse-spark-1.2-contributor": {
+          "npm": "@ai-sdk/openai"
+        },
+        "muse-spark-1.3-contributor": {
           "npm": "@ai-sdk/openai"
         },
         "qwen3.8-flash": {

--- a/scripts/model-metadata/models-dev-api.snapshot.json
+++ b/scripts/model-metadata/models-dev-api.snapshot.json
@@ -25,23 +25,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-fable-5-1": {
@@ -59,23 +47,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5": {
@@ -93,14 +69,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5-20251001": {
@@ -118,14 +88,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5": {
@@ -143,21 +107,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5-20251101": {
@@ -175,21 +129,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-6": {
@@ -207,22 +151,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-7": {
@@ -240,23 +173,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-8": {
@@ -274,23 +195,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -308,23 +217,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5": {
@@ -342,14 +239,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5-20250929": {
@@ -367,14 +258,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-6": {
@@ -392,22 +277,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -425,24 +299,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -462,19 +324,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -491,23 +346,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qvq-max": {
@@ -524,13 +367,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-flash": {
@@ -550,12 +388,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-max": {
@@ -572,12 +406,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-plus": {
@@ -594,12 +424,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-turbo": {
@@ -616,12 +442,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-omni-turbo": {
@@ -638,16 +460,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -664,15 +478,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-plus": {
@@ -692,12 +499,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-plus-character-ja": {
@@ -714,12 +517,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-turbo": {
@@ -739,12 +538,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-vl-max": {
@@ -761,13 +556,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-ocr": {
@@ -784,13 +574,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-plus": {
@@ -807,13 +592,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -830,12 +610,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -852,12 +628,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -874,12 +646,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -896,12 +664,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-omni-7b": {
@@ -918,16 +682,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -944,13 +700,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -967,13 +718,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-14b": {
@@ -993,12 +739,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-235b-a22b": {
@@ -1018,12 +760,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-32b": {
@@ -1043,12 +781,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-8b": {
@@ -1068,12 +802,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-asr-flash": {
@@ -1090,12 +820,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -1112,12 +838,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -1134,12 +856,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-flash": {
@@ -1156,12 +874,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -1178,12 +892,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-livetranslate-flash-realtime": {
@@ -1200,16 +910,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-max": {
@@ -1226,12 +928,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -1248,12 +946,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -1270,12 +964,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-omni-flash": {
@@ -1295,16 +985,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -1321,16 +1003,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -1347,13 +1021,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -1370,13 +1039,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-plus": {
@@ -1396,13 +1060,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-122b-a10b": {
@@ -1422,15 +1081,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-27b": {
@@ -1450,15 +1102,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-35b-a3b": {
@@ -1478,15 +1123,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -1506,15 +1144,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -1534,14 +1165,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-27b": {
@@ -1561,15 +1186,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.6-35b-a3b": {
@@ -1589,15 +1207,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -1617,14 +1228,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-max-preview": {
@@ -1644,12 +1249,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -1669,14 +1270,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -1695,12 +1290,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -1720,14 +1311,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -1744,22 +1329,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -1776,23 +1351,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "qwq-plus": {
@@ -1809,12 +1373,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -1832,12 +1392,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-0528": {
@@ -1853,12 +1409,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-llama-70b": {
@@ -1874,12 +1426,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-llama-8b": {
@@ -1896,12 +1444,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-1-5b": {
@@ -1918,12 +1462,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-14b": {
@@ -1939,12 +1479,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-32b": {
@@ -1960,12 +1496,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-r1-distill-qwen-7b": {
@@ -1981,12 +1513,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3": {
@@ -2002,12 +1530,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3-1": {
@@ -2023,12 +1547,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v3-2-exp": {
@@ -2044,12 +1564,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -2067,19 +1583,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -2097,19 +1606,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -2128,12 +1630,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -2153,12 +1651,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -2175,12 +1669,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking": {
@@ -2197,12 +1687,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -2223,14 +1709,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -2251,14 +1731,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi/kimi-k2.5": {
@@ -2279,14 +1753,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -2302,12 +1770,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax/MiniMax-M2.7": {
@@ -2323,12 +1787,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshot-kimi-k2-instruct": {
@@ -2345,12 +1805,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qvq-max": {
@@ -2367,13 +1823,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-deep-research": {
@@ -2390,12 +1841,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-doc-turbo": {
@@ -2412,12 +1859,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-flash": {
@@ -2437,12 +1880,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-long": {
@@ -2459,12 +1898,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-math-plus": {
@@ -2481,12 +1916,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-math-turbo": {
@@ -2503,12 +1934,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-max": {
@@ -2525,12 +1952,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-plus": {
@@ -2547,12 +1970,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-mt-turbo": {
@@ -2569,12 +1988,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-omni-turbo": {
@@ -2591,16 +2006,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-omni-turbo-realtime": {
@@ -2617,15 +2024,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen-plus": {
@@ -2645,12 +2045,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-plus-character": {
@@ -2667,12 +2063,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-turbo": {
@@ -2692,12 +2084,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-vl-max": {
@@ -2714,13 +2102,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-ocr": {
@@ -2737,13 +2120,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen-vl-plus": {
@@ -2760,13 +2138,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-14b-instruct": {
@@ -2783,12 +2156,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-32b-instruct": {
@@ -2805,12 +2174,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-72b-instruct": {
@@ -2827,12 +2192,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-7b-instruct": {
@@ -2849,12 +2210,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-coder-32b-instruct": {
@@ -2871,12 +2228,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-coder-7b-instruct": {
@@ -2893,12 +2246,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-math-72b-instruct": {
@@ -2915,12 +2264,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-math-7b-instruct": {
@@ -2937,12 +2282,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen2-5-omni-7b": {
@@ -2959,16 +2300,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen2-5-vl-72b-instruct": {
@@ -2985,13 +2318,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen2-5-vl-7b-instruct": {
@@ -3008,13 +2336,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-14b": {
@@ -3034,12 +2357,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-235b-a22b": {
@@ -3059,12 +2378,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-32b": {
@@ -3084,12 +2399,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-8b": {
@@ -3109,12 +2420,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-asr-flash": {
@@ -3131,12 +2438,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-30b-a3b-instruct": {
@@ -3153,12 +2456,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-480b-a35b-instruct": {
@@ -3175,12 +2474,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-flash": {
@@ -3197,12 +2492,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -3219,12 +2510,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max": {
@@ -3241,12 +2528,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-instruct": {
@@ -3263,12 +2546,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-next-80b-a3b-thinking": {
@@ -3285,12 +2564,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-omni-flash": {
@@ -3310,16 +2585,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-omni-flash-realtime": {
@@ -3336,15 +2603,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "qwen3-vl-235b-a22b": {
@@ -3361,13 +2621,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-30b-a3b": {
@@ -3384,13 +2639,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3-vl-plus": {
@@ -3410,13 +2660,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.5-397b-a17b": {
@@ -3436,14 +2681,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.5-flash": {
@@ -3464,14 +2703,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -3491,14 +2724,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -3518,14 +2745,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-max-preview": {
@@ -3545,12 +2766,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -3570,14 +2787,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-flash": {
@@ -3598,14 +2809,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -3624,12 +2829,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -3649,14 +2850,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -3673,22 +2868,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -3705,23 +2890,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "qwq-32b": {
@@ -3738,12 +2912,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwq-plus": {
@@ -3760,12 +2930,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-r1-0528": {
@@ -3782,12 +2948,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3-0324": {
@@ -3804,12 +2966,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3.1-terminus": {
@@ -3829,12 +2987,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "siliconflow/deepseek-v3.2": {
@@ -3854,12 +3008,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tongyi-intent-detect-v3": {
@@ -3876,12 +3026,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -3904,12 +3050,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -3929,12 +3071,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -3955,13 +3093,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -3978,12 +3111,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-next": {
@@ -4001,12 +3130,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -4024,12 +3149,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -4047,12 +3168,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -4073,13 +3190,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -4099,14 +3211,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -4127,14 +3233,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -4153,12 +3253,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -4179,14 +3275,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -4209,12 +3299,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -4234,12 +3320,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -4260,14 +3342,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -4285,12 +3361,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-next": {
@@ -4308,12 +3380,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder-plus": {
@@ -4331,12 +3399,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-max-2026-01-23": {
@@ -4354,12 +3418,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -4380,14 +3440,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-flash": {
@@ -4407,14 +3461,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -4435,14 +3483,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -4461,12 +3503,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -4487,14 +3525,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -4518,12 +3550,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -4542,19 +3570,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -4573,19 +3594,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -4604,19 +3618,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -4634,19 +3641,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -4667,12 +3667,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -4693,12 +3689,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -4716,18 +3708,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -4744,13 +3729,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["image", "text"],
+            "output": ["video"]
           }
         },
         "happyhorse-1.1-r2v": {
@@ -4767,13 +3747,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["image", "text"],
+            "output": ["video"]
           }
         },
         "happyhorse-1.1-t2v": {
@@ -4790,12 +3765,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "kimi-k2.5": {
@@ -4817,14 +3788,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -4846,14 +3811,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -4875,14 +3834,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -4900,12 +3853,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-image-2.0": {
@@ -4922,12 +3871,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen-image-2.0-pro": {
@@ -4944,12 +3889,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen3.6-flash": {
@@ -4970,14 +3911,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -4999,14 +3934,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -5027,12 +3956,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -5054,14 +3979,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -5079,22 +3998,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -5112,23 +4021,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max-preview": {
@@ -5146,21 +4044,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "wan2.7-image": {
@@ -5177,12 +4065,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "wan2.7-image-pro": {
@@ -5199,12 +4083,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         }
       },
@@ -5228,12 +4108,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -5252,19 +4128,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-0731": {
@@ -5283,19 +4152,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -5314,19 +4176,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro-0813": {
@@ -5344,19 +4199,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -5377,12 +4225,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -5403,12 +4247,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -5426,18 +4266,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "happyhorse-1.1-i2v": {
@@ -5454,13 +4287,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["image", "text"],
+            "output": ["video"]
           }
         },
         "happyhorse-1.1-r2v": {
@@ -5477,13 +4305,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["image", "text"],
+            "output": ["video"]
           }
         },
         "happyhorse-1.1-t2v": {
@@ -5500,12 +4323,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "kimi-k2.5": {
@@ -5527,14 +4346,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -5556,14 +4369,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -5585,14 +4392,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -5610,12 +4411,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-image-2.0": {
@@ -5632,12 +4429,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen-image-2.0-pro": {
@@ -5654,12 +4447,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "qwen3.6-flash": {
@@ -5680,14 +4469,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -5709,14 +4492,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -5737,12 +4514,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -5764,14 +4537,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -5789,22 +4556,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -5822,23 +4579,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max-preview": {
@@ -5856,21 +4602,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "wan2.7-image": {
@@ -5887,12 +4623,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "wan2.7-image-pro": {
@@ -5909,12 +4641,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         }
       },
@@ -5933,19 +4661,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen-3.8-27b": {
@@ -5962,21 +4682,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -5994,12 +4704,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-expanse-8b": {
@@ -6015,12 +4721,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-vision-32b": {
@@ -6036,13 +4738,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "c4ai-aya-vision-8b": {
@@ -6058,13 +4755,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-a-03-2025": {
@@ -6081,12 +4773,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-plus-05-2026": {
@@ -6107,13 +4795,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-a-reasoning-08-2025": {
@@ -6133,12 +4816,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-translate-08-2025": {
@@ -6155,12 +4834,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-a-vision-07-2025": {
@@ -6177,13 +4852,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "command-r-08-2024": {
@@ -6200,12 +4870,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r-plus-08-2024": {
@@ -6222,12 +4888,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r7b-12-2024": {
@@ -6244,12 +4906,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "command-r7b-arabic-02-2025": {
@@ -6266,12 +4924,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "north-mini-code-1-0": {
@@ -6290,18 +4944,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -6320,12 +4967,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
@@ -6343,12 +4986,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-flash-0731": {
@@ -6366,19 +5005,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/deepseek-ai/deepseek-v4-pro-0813": {
@@ -6395,19 +5027,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/google/gemma-4-26b-a4b-it": {
@@ -6424,21 +5049,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/ibm-granite/granite-4.0-h-micro": {
@@ -6455,12 +5071,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.1-8b-instruct-fp8": {
@@ -6478,12 +5090,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-11b-vision-instruct": {
@@ -6501,13 +5109,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-1b-instruct": {
@@ -6525,12 +5128,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.2-3b-instruct": {
@@ -6548,12 +5147,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
@@ -6571,12 +5166,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-4-scout-17b-16e-instruct": {
@@ -6594,13 +5185,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/meta/llama-guard-3-8b": {
@@ -6618,12 +5204,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/mistralai/mistral-small-3.1-24b-instruct": {
@@ -6640,12 +5222,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/moonshotai/kimi-k2.6": {
@@ -6663,21 +5241,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/moonshotai/kimi-k2.7-code": {
@@ -6695,21 +5264,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/nvidia/nemotron-3-120b-a12b": {
@@ -6726,20 +5286,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/openai/gpt-oss-120b": {
@@ -6756,19 +5308,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/openai/gpt-oss-20b": {
@@ -6785,12 +5329,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen2.5-coder-32b-instruct": {
@@ -6807,12 +5347,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen3-30b-a3b-fp8": {
@@ -6829,12 +5365,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwen3.8-27b": {
@@ -6851,21 +5383,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "@cf/qwen/qwq-32b": {
@@ -6883,12 +5406,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-4.7-flash": {
@@ -6906,20 +5425,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.2": {
@@ -6936,20 +5447,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.3": {
@@ -6966,19 +5469,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "@cf/zai-org/glm-5.3-flash": {
@@ -6995,13 +5490,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -7020,21 +5510,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ByteDance/Seed-2.0-mini": {
@@ -7051,13 +5531,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ByteDance/Seed-2.0-pro": {
@@ -7074,13 +5549,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -7098,12 +5568,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -7120,12 +5586,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -7142,12 +5604,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -7167,12 +5625,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -7193,12 +5647,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -7216,21 +5666,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -7251,12 +5692,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp": {
@@ -7273,21 +5710,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -7305,21 +5732,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -7336,19 +5754,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4.1-Flash": {
@@ -7366,22 +5777,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -7399,13 +5799,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-27b-it": {
@@ -7423,13 +5818,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -7447,13 +5837,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -7473,13 +5858,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -7499,14 +5879,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-E4B-it": {
@@ -7526,14 +5900,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -7550,12 +5918,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -7572,13 +5936,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
@@ -7595,13 +5954,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -7618,12 +5972,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -7639,12 +5989,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -7661,14 +6007,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -7689,14 +6029,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -7717,14 +6051,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -7745,14 +6073,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -7769,20 +6091,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
@@ -7799,12 +6112,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/Nemotron-3-Nano-30B-A3B": {
@@ -7823,12 +6132,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": {
@@ -7845,15 +6150,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -7870,19 +6168,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -7899,19 +6189,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -7928,12 +6210,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -7950,12 +6228,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -7973,12 +6247,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
@@ -7996,12 +6266,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Max": {
@@ -8019,12 +6285,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -8042,12 +6304,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -8065,13 +6323,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -8088,15 +6341,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -8113,15 +6359,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -8139,14 +6378,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -8164,14 +6397,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -8188,14 +6415,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -8212,15 +6433,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -8237,14 +6451,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -8261,12 +6469,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -8283,19 +6487,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -8312,21 +6508,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-Max": {
@@ -8343,15 +6530,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -8368,14 +6548,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3": {
@@ -8393,12 +6567,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -8414,14 +6584,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -8438,14 +6602,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -8466,15 +6624,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -8495,13 +6646,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6": {
@@ -8522,12 +6668,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7": {
@@ -8548,12 +6690,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -8571,12 +6709,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -8597,12 +6731,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -8623,12 +6753,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -8645,21 +6771,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -8676,19 +6793,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -8705,22 +6814,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -8740,21 +6838,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -8772,21 +6861,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -8804,21 +6884,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -8835,19 +6906,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -8867,20 +6931,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
@@ -8897,21 +6953,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -8928,19 +6975,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/deepseek-v4p1-flash": {
@@ -8958,21 +6998,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p2": {
@@ -8988,19 +7019,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p3": {
@@ -9017,19 +7041,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/glm-5p3-flash": {
@@ -9046,22 +7062,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -9077,19 +7082,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/inkling": {
@@ -9105,14 +7102,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k2p6": {
@@ -9131,13 +7122,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k2p7-code": {
@@ -9156,13 +7142,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/kimi-k3": {
@@ -9179,22 +7160,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/minimax-m3": {
@@ -9210,21 +7181,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/mistral-large-3-fp8": {
@@ -9241,13 +7202,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/muse-glimmer-30b": {
@@ -9265,21 +7221,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
@@ -9298,12 +7244,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
@@ -9323,12 +7265,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/qwen3p7-plus": {
@@ -9344,21 +7282,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/qwen3p8-2p4t-a95b": {
@@ -9375,19 +7304,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/models/qwen3p8-max": {
@@ -9406,12 +7327,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/routers/glm-5p2-fast": {
@@ -9427,19 +7344,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/routers/glm-5p3-fast": {
@@ -9456,19 +7366,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "accounts/fireworks/routers/kimi-k3-fast": {
@@ -9485,22 +7387,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -9519,23 +7411,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-fable-5.1": {
@@ -9552,23 +7432,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4.5": {
@@ -9586,14 +7454,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.7": {
@@ -9611,23 +7473,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4.8": {
@@ -9645,23 +7495,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -9680,23 +7518,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4.6": {
@@ -9714,22 +7540,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -9746,23 +7561,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -9781,24 +7584,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.6-flash": {
@@ -9817,22 +7607,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -9851,20 +7630,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemini-3.8-flash": {
@@ -9882,20 +7652,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-mini": {
@@ -9914,20 +7675,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -9946,22 +7698,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -9980,23 +7721,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -10015,22 +7744,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -10049,13 +7767,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -10074,23 +7787,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -10109,24 +7810,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -10145,24 +7833,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -10181,24 +7856,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-6-astra": {
@@ -10217,23 +7879,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -10251,20 +7901,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -10283,21 +7924,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -10316,13 +7947,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -10339,20 +7965,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mai-code-1-flash-picker": {
@@ -10371,19 +7988,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mai-code-1.1-flash": {
@@ -10401,21 +8010,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -10434,17 +8033,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "deep-research-preview-04-2026": {
@@ -10461,17 +8051,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-2.5-computer-use-preview-10-2025": {
@@ -10488,13 +8069,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash": {
@@ -10515,16 +8091,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash-image": {
@@ -10541,14 +8109,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-2.5-flash-lite": {
@@ -10569,16 +8131,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-flash-preview-tts": {
@@ -10595,12 +8149,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-2.5-pro": {
@@ -10618,16 +8168,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-2.5-pro-preview-tts": {
@@ -10644,12 +8186,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-3-flash-preview": {
@@ -10667,24 +8205,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3-pro-image": {
@@ -10701,20 +8226,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3-pro-image-preview": {
@@ -10731,14 +8247,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-image": {
@@ -10755,22 +8265,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-image-preview": {
@@ -10787,21 +8286,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-lite": {
@@ -10819,24 +8308,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-flash-lite-image": {
@@ -10854,20 +8330,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gemini-3.1-flash-lite-preview": {
@@ -10885,24 +8352,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-flash-live-preview": {
@@ -10920,24 +8374,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "gemini-3.1-flash-tts-preview": {
@@ -10954,12 +8395,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "gemini-3.1-pro-preview": {
@@ -10977,23 +8414,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-pro-preview-customtools": {
@@ -11011,23 +8436,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -11045,24 +8458,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -11080,24 +8480,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-live-translate-preview": {
@@ -11114,13 +8501,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "audio",
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["audio", "text"]
           }
         },
         "gemini-3.6-flash": {
@@ -11138,24 +8520,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -11173,23 +8542,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.8-flash": {
@@ -11206,23 +8563,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-embedding-001": {
@@ -11239,12 +8584,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gemini-embedding-2": {
@@ -11261,16 +8602,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-flash-latest": {
@@ -11288,23 +8621,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-flash-lite-latest": {
@@ -11322,24 +8643,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-omni-flash-preview": {
@@ -11355,14 +8663,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["video"]
           }
         },
         "gemma-4-26b-a4b-it": {
@@ -11382,13 +8684,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemma-4-31b-it": {
@@ -11408,13 +8705,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "lyria-3-clip-preview": {
@@ -11432,14 +8724,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "lyria-3-pro-preview": {
@@ -11457,14 +8743,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "veo-3.1-fast-generate-preview": {
@@ -11480,14 +8760,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["video"]
           }
         },
         "veo-3.1-generate-preview": {
@@ -11503,13 +8777,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "veo-3.1-lite-generate-preview": {
@@ -11525,13 +8794,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         }
       },
@@ -11550,12 +8814,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "canopylabs/orpheus-arabic-saudi": {
@@ -11571,12 +8831,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "canopylabs/orpheus-v1-english": {
@@ -11592,12 +8848,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "groq/compound": {
@@ -11613,12 +8865,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "groq/compound-mini": {
@@ -11634,12 +8882,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "llama-3.1-8b-instant": {
@@ -11656,12 +8900,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "llama-3.3-70b-versatile": {
@@ -11678,12 +8918,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-prompt-guard-2-22m": {
@@ -11699,12 +8935,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-prompt-guard-2-86m": {
@@ -11720,12 +8952,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -11742,19 +8970,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -11771,19 +8991,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -11800,19 +9012,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -11829,19 +9033,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "default"
-            ]
+            "efforts": ["none", "default"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -11858,22 +9054,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "default",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "default", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "whisper-large-v3": {
@@ -11889,12 +9074,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "whisper-large-v3-turbo": {
@@ -11910,12 +9091,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         }
       },
@@ -11935,12 +9112,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1-0528": {
@@ -11957,12 +9130,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -11979,12 +9148,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-0324": {
@@ -12001,12 +9166,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -12023,12 +9184,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -12045,12 +9202,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -12068,12 +9221,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -12091,18 +9240,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp": {
@@ -12119,20 +9261,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -12150,17 +9283,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -12177,19 +9304,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4.1-Flash": {
@@ -12207,22 +9326,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -12240,13 +9348,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-27b-it": {
@@ -12264,13 +9367,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -12288,13 +9386,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -12311,13 +9404,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -12334,13 +9422,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.1-8B-Instruct": {
@@ -12358,12 +9441,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct": {
@@ -12381,12 +9460,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2": {
@@ -12402,12 +9477,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.1": {
@@ -12424,12 +9495,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -12445,12 +9512,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -12467,12 +9530,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -12489,13 +9548,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Instruct": {
@@ -12512,12 +9566,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Instruct-0905": {
@@ -12534,12 +9584,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2-Thinking": {
@@ -12556,12 +9602,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -12578,14 +9620,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -12602,14 +9638,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -12627,13 +9657,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -12650,20 +9675,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -12680,19 +9696,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -12709,19 +9717,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-Coder-32B-Instruct": {
@@ -12738,12 +9738,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B": {
@@ -12761,12 +9757,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -12783,12 +9775,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -12805,12 +9793,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B": {
@@ -12827,12 +9811,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -12850,12 +9830,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -12873,12 +9849,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -12895,12 +9867,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-Next": {
@@ -12917,12 +9885,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Embedding-4B": {
@@ -12939,12 +9903,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Embedding-8B": {
@@ -12961,12 +9921,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Instruct": {
@@ -12983,12 +9939,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Next-80B-A3B-Thinking": {
@@ -13005,12 +9957,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -13028,13 +9976,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -13052,20 +9995,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -13082,13 +10016,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -13105,13 +10034,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -13128,13 +10052,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -13151,21 +10070,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -13182,13 +10091,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -13205,13 +10109,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -13228,13 +10127,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-2.4T-A95B": {
@@ -13251,19 +10145,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.8-27B": {
@@ -13280,20 +10166,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -13310,12 +10187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.7-Flash": {
@@ -13332,21 +10205,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3": {
@@ -13364,19 +10227,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -13393,20 +10248,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling-Small": {
@@ -13422,13 +10268,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2-Flash": {
@@ -13445,12 +10286,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5": {
@@ -13468,22 +10305,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["none", "low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "XiaomiMiMo/MiMo-V2.5-Pro": {
@@ -13501,22 +10328,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["none", "low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5": {
@@ -13533,12 +10350,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -13555,12 +10368,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5V": {
@@ -13577,13 +10386,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6": {
@@ -13600,12 +10404,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.6V-Flash": {
@@ -13624,13 +10424,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7": {
@@ -13647,12 +10442,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.7-Flash": {
@@ -13670,12 +10461,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -13691,12 +10478,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -13712,12 +10495,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -13734,12 +10513,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -13756,19 +10531,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -13785,20 +10552,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -13818,22 +10576,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "k3-256k": {
@@ -13851,20 +10599,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-for-coding": {
@@ -13883,14 +10622,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-for-coding-highspeed": {
@@ -13909,14 +10642,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -13934,12 +10661,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -13955,12 +10678,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -13976,12 +10695,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -13997,12 +10712,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14018,12 +10729,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14039,12 +10746,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14063,14 +10766,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -14088,12 +10785,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -14109,12 +10802,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -14130,12 +10819,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -14151,12 +10836,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14172,12 +10853,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14193,12 +10870,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14217,14 +10890,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -14243,12 +10910,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.1": {
@@ -14265,12 +10928,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5": {
@@ -14287,12 +10946,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.5-highspeed": {
@@ -14309,12 +10964,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7": {
@@ -14331,12 +10982,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M2.7-highspeed": {
@@ -14353,12 +11000,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMax-M3": {
@@ -14378,14 +11021,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -14404,12 +11041,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-2512": {
@@ -14426,12 +11059,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-latest": {
@@ -14448,12 +11077,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-medium-2507": {
@@ -14470,12 +11095,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-medium-latest": {
@@ -14492,12 +11113,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-small-2505": {
@@ -14514,12 +11131,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "devstral-small-2507": {
@@ -14536,12 +11149,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "labs-devstral-small-2512": {
@@ -14559,13 +11168,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "magistral-medium-latest": {
@@ -14582,12 +11186,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "magistral-small": {
@@ -14604,12 +11204,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ministral-3b-latest": {
@@ -14626,12 +11222,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ministral-8b-latest": {
@@ -14648,12 +11240,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-embed": {
@@ -14669,12 +11257,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-large-2411": {
@@ -14691,12 +11275,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-large-2512": {
@@ -14713,13 +11293,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-large-latest": {
@@ -14736,13 +11311,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2505": {
@@ -14759,13 +11329,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2508": {
@@ -14782,13 +11347,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-2604": {
@@ -14805,19 +11365,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-medium-latest": {
@@ -14834,19 +11386,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-nemo": {
@@ -14863,12 +11407,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral-small-2506": {
@@ -14885,13 +11425,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-small-2603": {
@@ -14908,19 +11443,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral-small-latest": {
@@ -14937,19 +11464,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "open-mistral-7b": {
@@ -14966,12 +11485,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mistral-nemo": {
@@ -14988,12 +11503,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mixtral-8x22b": {
@@ -15010,12 +11521,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "open-mixtral-8x7b": {
@@ -15032,12 +11539,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "pixtral-12b": {
@@ -15054,13 +11557,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "pixtral-large-latest": {
@@ -15077,13 +11575,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "voxtral-mini-latest": {
@@ -15099,12 +11592,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "voxtral-mini-tts-latest": {
@@ -15120,12 +11609,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "voxtral-small-latest": {
@@ -15141,13 +11626,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "zai-glm-5-2": {
@@ -15164,18 +11644,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -15198,14 +11671,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -15223,14 +11690,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code-highspeed": {
@@ -15248,14 +11709,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -15272,22 +11727,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -15306,12 +11751,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "baai/bge-m3": {
@@ -15328,12 +11769,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "black-forest-labs/flux_1-kontext-dev": {
@@ -15350,13 +11787,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux_1-schnell": {
@@ -15376,12 +11808,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux_2-klein-4b": {
@@ -15399,13 +11827,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["image"]
           }
         },
         "black-forest-labs/flux.1-dev": {
@@ -15423,12 +11846,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seed-oss-36b-instruct": {
@@ -15446,12 +11865,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-flash": {
@@ -15469,19 +11884,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-flash-0731": {
@@ -15500,19 +11907,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-pro": {
@@ -15530,19 +11929,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/deepseek-v4-pro-0813": {
@@ -15560,19 +11951,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-2-2b-it": {
@@ -15590,12 +11973,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -15612,13 +11991,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -15635,13 +12009,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-e2b-it": {
@@ -15660,13 +12029,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-e4b-it": {
@@ -15685,13 +12049,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -15712,14 +12071,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "google/google-paligemma": {
@@ -15736,13 +12089,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/esm2-650m": {
@@ -15759,12 +12107,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/esmfold": {
@@ -15781,12 +12125,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-70b-instruct": {
@@ -15804,12 +12144,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-8b-instruct": {
@@ -15827,12 +12163,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-11b-vision-instruct": {
@@ -15851,13 +12183,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-1b-instruct": {
@@ -15876,12 +12203,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-3b-instruct": {
@@ -15899,12 +12222,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.2-90b-vision-instruct": {
@@ -15922,13 +12241,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.3-70b-instruct": {
@@ -15946,12 +12260,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-maverick-17b-128e-instruct": {
@@ -15970,13 +12280,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-guard-4-12b": {
@@ -15993,13 +12298,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -16018,23 +12318,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4-mini-instruct": {
@@ -16052,12 +12340,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4-multimodal-instruct": {
@@ -16076,12 +12360,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimaxai/minimax-m2.7": {
@@ -16098,12 +12378,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimaxai/minimax-m3": {
@@ -16123,14 +12399,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "mistralai/magistral-small-2506": {
@@ -16149,12 +12419,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-14b-instruct-2512": {
@@ -16171,13 +12437,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-7b-instruct-v0.3": {
@@ -16195,12 +12456,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-3-675b-instruct-2512": {
@@ -16219,13 +12476,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3-instruct": {
@@ -16244,13 +12496,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3.5-128b": {
@@ -16268,19 +12515,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-nemotron": {
@@ -16297,12 +12536,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-4-119b-2603": {
@@ -16320,19 +12555,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -16349,12 +12576,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x7b-instruct": {
@@ -16371,12 +12594,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-instruct-0905": {
@@ -16394,12 +12613,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -16418,25 +12633,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -16454,22 +12655,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "nvidia/active-speaker-detection": {
@@ -16486,12 +12677,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["video"],
+            "output": ["text"]
           }
         },
         "nvidia/bevformer": {
@@ -16508,12 +12695,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["video"],
+            "output": ["text"]
           }
         },
         "nvidia/cosmos-predict1-5b": {
@@ -16530,14 +12713,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["video"]
           }
         },
         "nvidia/cosmos-reason2-8b": {
@@ -16554,14 +12731,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "nvidia/cosmos-transfer1-7b": {
@@ -16578,14 +12749,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["video"]
           }
         },
         "nvidia/cosmos-transfer2_5-2b": {
@@ -16602,14 +12767,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["video"]
           }
         },
         "nvidia/gliner-pii": {
@@ -16626,12 +12785,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
@@ -16648,12 +12803,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -16670,12 +12821,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-8b-v1": {
@@ -16695,12 +12842,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
@@ -16717,13 +12860,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
@@ -16740,12 +12878,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.1-nemotron-ultra-253b-v1": {
@@ -16765,12 +12899,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1": {
@@ -16790,12 +12920,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
@@ -16815,12 +12941,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-nemotron-embed-vl-1b-v2": {
@@ -16837,13 +12959,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/llama-nemotron-rerank-vl-1b-v2": {
@@ -16860,13 +12977,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/magpie-tts-zeroshot": {
@@ -16883,13 +12995,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["audio"]
           }
         },
         "nvidia/nemotron-3-content-safety": {
@@ -16906,12 +13013,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -16932,12 +13035,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
@@ -16958,15 +13057,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -16986,12 +13078,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -17011,12 +13099,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning-30b-a3b": {
@@ -17037,12 +13121,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-content-safety-reasoning-4b": {
@@ -17059,12 +13139,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-mini-4b-instruct": {
@@ -17081,12 +13157,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -17103,14 +13175,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-voicechat": {
@@ -17127,13 +13193,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nv-embed-v1": {
@@ -17150,12 +13211,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nv-embedcode-7b-v1": {
@@ -17172,12 +13229,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nvidia-nemotron-nano-9b-v2": {
@@ -17198,12 +13251,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/rerank-qa-mistral-4b": {
@@ -17220,12 +13269,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/riva-translate-4b-instruct-v1.1": {
@@ -17242,12 +13287,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/sparsedrive": {
@@ -17264,12 +13305,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["video"],
+            "output": ["text"]
           }
         },
         "nvidia/streampetr": {
@@ -17286,12 +13323,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["video"],
+            "output": ["text"]
           }
         },
         "nvidia/studiovoice": {
@@ -17308,12 +13341,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/synthetic-video-detector": {
@@ -17330,12 +13359,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["video"],
+            "output": ["text"]
           }
         },
         "nvidia/usdcode": {
@@ -17352,12 +13377,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/usdvalidate": {
@@ -17374,12 +13395,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -17398,19 +13415,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -17428,19 +13437,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/whisper-large-v3": {
@@ -17458,12 +13459,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -17481,12 +13478,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-image": {
@@ -17504,13 +13497,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "qwen/qwen-image-edit": {
@@ -17528,13 +13516,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "qwen/qwen2.5-coder-32b-instruct": {
@@ -17552,12 +13535,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-480b-a35b-instruct": {
@@ -17575,12 +13554,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -17598,12 +13573,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -17624,15 +13595,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -17654,13 +13618,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sarvamai/sarvam-m": {
@@ -17677,12 +13636,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/step-3.5-flash": {
@@ -17699,19 +13654,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/step-3.7-flash": {
@@ -17728,23 +13675,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -17761,14 +13696,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "upstage/solar-10.7b-instruct": {
@@ -17785,12 +13714,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -17811,12 +13736,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -17834,19 +13755,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash:0731": {
@@ -17864,19 +13778,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -17892,19 +13799,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4.1-flash": {
@@ -17922,21 +13822,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gemma4:31b": {
@@ -17956,13 +13847,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -17981,12 +13867,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -18003,18 +13885,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -18031,19 +13906,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -18060,22 +13927,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-oss:120b": {
@@ -18091,19 +13947,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-oss:20b": {
@@ -18119,19 +13967,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -18150,13 +13990,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -18175,13 +14010,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -18202,13 +14032,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -18225,21 +14050,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -18256,12 +14072,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -18280,12 +14092,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -18302,23 +14110,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "mistral-large-3:675b": {
@@ -18334,13 +14131,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nemotron-3-nano:30b": {
@@ -18359,12 +14151,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-super": {
@@ -18383,12 +14171,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-ultra": {
@@ -18407,12 +14191,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5:397b": {
@@ -18431,13 +14211,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -18456,14 +14231,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-3.5-turbo": {
@@ -18481,12 +14250,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-4": {
@@ -18504,12 +14269,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-4-turbo": {
@@ -18527,13 +14288,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4.1": {
@@ -18551,14 +14307,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4.1-mini": {
@@ -18576,14 +14326,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4.1-nano": {
@@ -18601,13 +14345,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o": {
@@ -18625,14 +14364,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-05-13": {
@@ -18650,13 +14383,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-08-06": {
@@ -18674,13 +14402,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-2024-11-20": {
@@ -18698,13 +14421,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-4o-mini": {
@@ -18722,14 +14440,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5": {
@@ -18748,21 +14460,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-mini": {
@@ -18781,21 +14483,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-nano": {
@@ -18814,21 +14506,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-pro": {
@@ -18847,18 +14529,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1": {
@@ -18877,21 +14552,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2": {
@@ -18910,22 +14575,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-chat-latest": {
@@ -18943,18 +14597,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium"
-            ]
+            "efforts": ["medium"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-pro": {
@@ -18973,20 +14620,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-chat-latest": {
@@ -19004,13 +14642,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -19029,23 +14662,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -19064,23 +14685,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -19099,23 +14708,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -19134,22 +14731,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -19168,22 +14754,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-pro": {
@@ -19202,20 +14777,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -19234,23 +14800,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5-pro": {
@@ -19269,21 +14823,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6": {
@@ -19302,24 +14846,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -19338,24 +14869,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -19374,24 +14892,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -19410,24 +14915,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-6-astra": {
@@ -19446,23 +14938,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-image-1": {
@@ -19479,13 +14959,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "gpt-image-1-mini": {
@@ -19502,14 +14977,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-image-1.5": {
@@ -19526,14 +14995,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "gpt-image-2": {
@@ -19550,13 +15013,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "gpt-realtime-2.1": {
@@ -19575,24 +15033,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio", "image"],
+            "output": ["text", "audio"]
           }
         },
         "o1": {
@@ -19610,21 +15055,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "o1-pro": {
@@ -19642,20 +15077,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "o3": {
@@ -19673,21 +15099,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "o3-mini": {
@@ -19705,19 +15121,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "o3-pro": {
@@ -19735,20 +15143,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "o4-mini": {
@@ -19766,20 +15165,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "text-embedding-3-large": {
@@ -19796,12 +15186,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "text-embedding-3-small": {
@@ -19818,12 +15204,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "text-embedding-ada-002": {
@@ -19840,12 +15222,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -19867,12 +15245,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "claude-3-5-haiku": {
@@ -19889,14 +15263,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-fable-5": {
@@ -19913,23 +15281,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-fable-5-1": {
@@ -19946,23 +15302,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-haiku-4-5": {
@@ -19979,14 +15323,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-1": {
@@ -20003,14 +15341,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-5": {
@@ -20027,21 +15359,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-6": {
@@ -20058,22 +15380,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-7": {
@@ -20090,23 +15401,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-4-8": {
@@ -20123,23 +15422,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-opus-5": {
@@ -20156,23 +15443,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4": {
@@ -20189,14 +15464,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-5": {
@@ -20213,14 +15482,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-4-6": {
@@ -20237,22 +15500,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "claude-sonnet-5": {
@@ -20269,23 +15521,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash": {
@@ -20303,20 +15543,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-free": {
@@ -20335,19 +15567,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -20364,21 +15588,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -20396,19 +15611,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gemini-3-flash": {
@@ -20426,24 +15634,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3-pro": {
@@ -20461,22 +15656,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.1-pro": {
@@ -20494,23 +15678,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash": {
@@ -20528,24 +15700,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.5-flash-lite": {
@@ -20563,24 +15722,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.6-flash": {
@@ -20598,24 +15744,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.7-flash": {
@@ -20633,23 +15766,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "gemini-3.8-flash": {
@@ -20666,23 +15787,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-4.6": {
@@ -20702,12 +15811,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7": {
@@ -20727,12 +15832,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-free": {
@@ -20753,12 +15854,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -20778,12 +15875,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-free": {
@@ -20804,12 +15897,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -20829,12 +15918,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -20851,18 +15936,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -20879,19 +15957,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -20908,22 +15978,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5": {
@@ -20942,21 +16001,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-codex": {
@@ -20975,20 +16024,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5-nano": {
@@ -21007,21 +16047,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1": {
@@ -21040,21 +16070,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex": {
@@ -21073,20 +16093,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex-max": {
@@ -21105,21 +16116,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.1-codex-mini": {
@@ -21138,20 +16139,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2": {
@@ -21170,22 +16162,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "gpt-5.2-codex": {
@@ -21204,22 +16185,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex": {
@@ -21238,23 +16208,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.3-codex-spark": {
@@ -21273,20 +16231,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "gpt-5.4": {
@@ -21305,23 +16254,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-mini": {
@@ -21340,23 +16277,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-nano": {
@@ -21375,23 +16300,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.4-pro": {
@@ -21410,21 +16323,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5": {
@@ -21443,23 +16346,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.5-pro": {
@@ -21478,21 +16369,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -21511,24 +16392,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-sol": {
@@ -21547,24 +16415,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-terra": {
@@ -21583,24 +16438,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-6-astra": {
@@ -21619,23 +16461,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -21652,20 +16482,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -21683,21 +16504,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-build-0.1": {
@@ -21714,14 +16525,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-code": {
@@ -21738,12 +16543,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-free": {
@@ -21762,20 +16563,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-preview-free": {
@@ -21793,12 +16586,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2": {
@@ -21815,12 +16604,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2-thinking": {
@@ -21837,12 +16622,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -21862,14 +16643,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5-free": {
@@ -21890,14 +16665,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -21917,14 +16686,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -21942,14 +16705,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -21966,19 +16723,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ]
+            "efforts": ["max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "laguna-s-2.1-free": {
@@ -21996,19 +16745,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-2.6-flash-free": {
@@ -22026,12 +16767,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-flash-fin-free": {
@@ -22052,12 +16789,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-flash-free": {
@@ -22075,19 +16808,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ling-3.0-tiny-free": {
@@ -22105,12 +16830,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "longcat-2.0-free": {
@@ -22130,12 +16851,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-flash-free": {
@@ -22153,12 +16870,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni-free": {
@@ -22176,15 +16889,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro-free": {
@@ -22202,12 +16908,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-free": {
@@ -22225,15 +16927,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "minimax-m2.1": {
@@ -22250,12 +16945,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.1-free": {
@@ -22273,12 +16964,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -22295,12 +16982,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5-free": {
@@ -22318,12 +17001,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -22340,12 +17019,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -22361,14 +17036,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "minimax-m3-free": {
@@ -22389,14 +17058,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2": {
@@ -22413,25 +17076,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2-contributor-free": {
@@ -22449,25 +17098,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.3": {
@@ -22484,26 +17119,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.3-contributor-free": {
@@ -22521,25 +17141,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "nemotron-3-super-free": {
@@ -22557,12 +17163,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3-ultra-free": {
@@ -22580,12 +17182,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nemotron-3.5-lightning-free": {
@@ -22603,12 +17201,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "north-mini-code-free": {
@@ -22627,18 +17221,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3-coder": {
@@ -22655,12 +17242,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -22680,14 +17263,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -22707,14 +17284,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus-free": {
@@ -22735,14 +17306,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "ring-2.6-1t-free": {
@@ -22760,12 +17325,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "trinity-large-preview-free": {
@@ -22783,12 +17344,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "x-preview-f-free": {
@@ -22806,21 +17363,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -22840,19 +17387,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-flash-vision-exp": {
@@ -22869,21 +17408,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek-v4-pro": {
@@ -22901,18 +17431,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-v4.1-flash": {
@@ -22930,20 +17453,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -22960,12 +17474,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -22982,12 +17492,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -23004,18 +17510,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -23032,19 +17531,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -23061,22 +17552,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "gpt-5.6-luna": {
@@ -23095,24 +17575,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -23129,20 +17596,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -23160,21 +17618,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "hy3": {
@@ -23191,19 +17639,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -23219,18 +17659,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -23247,14 +17680,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.6": {
@@ -23271,14 +17698,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k2.7-code": {
@@ -23296,14 +17717,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "kimi-k3": {
@@ -23320,19 +17735,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ]
+            "efforts": ["max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "longcat-2.0": {
@@ -23351,12 +17758,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni": {
@@ -23373,15 +17776,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro": {
@@ -23398,12 +17794,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5": {
@@ -23420,15 +17812,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -23445,12 +17830,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -23467,12 +17848,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m2.7": {
@@ -23489,12 +17866,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax-m3": {
@@ -23514,14 +17887,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.2-contributor": {
@@ -23538,25 +17905,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "muse-spark-1.3-contributor": {
@@ -23573,25 +17926,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "omen-alpha": {
@@ -23608,19 +17947,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "ox-alpha-free": {
@@ -23638,21 +17969,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.5-plus": {
@@ -23672,14 +17993,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.6-plus": {
@@ -23699,14 +18014,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.7-max": {
@@ -23725,12 +18034,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen3.7-plus": {
@@ -23749,14 +18054,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-flash": {
@@ -23773,22 +18072,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen3.8-max": {
@@ -23805,22 +18094,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -23839,23 +18118,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-haiku-latest": {
@@ -23875,14 +18142,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-opus-latest": {
@@ -23899,24 +18160,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~anthropic/claude-sonnet-latest": {
@@ -23934,24 +18183,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~deepseek/deepseek-v4-flash-latest": {
@@ -23968,20 +18205,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "~google/gemini-flash-latest": {
@@ -23999,23 +18228,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "~google/gemini-pro-latest": {
@@ -24033,23 +18250,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "audio",
-              "pdf",
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio", "pdf", "image", "text", "video"],
+            "output": ["text"]
           }
         },
         "~moonshotai/kimi-latest": {
@@ -24066,22 +18271,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-astra-latest": {
@@ -24098,23 +18293,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-luna-latest": {
@@ -24132,24 +18315,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-mini-latest": {
@@ -24167,23 +18337,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-sol-latest": {
@@ -24201,24 +18359,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~openai/gpt-terra-latest": {
@@ -24236,24 +18381,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "~x-ai/grok-latest": {
@@ -24270,22 +18402,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "~z-ai/glm-flash-latest": {
@@ -24302,21 +18423,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "~z-ai/glm-latest": {
@@ -24333,19 +18444,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-2.0": {
@@ -24362,12 +18465,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-3.0": {
@@ -24384,12 +18483,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-3.0-mini": {
@@ -24406,12 +18501,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "aion-labs/aion-rp-llama-3.1-8b": {
@@ -24429,12 +18520,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-2-lite-v1": {
@@ -24454,15 +18541,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/nova-lite-v1": {
@@ -24480,13 +18560,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/nova-micro-v1": {
@@ -24504,12 +18579,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-premier-v1": {
@@ -24526,13 +18597,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "amazon/nova-pro-v1": {
@@ -24550,13 +18616,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthracite-org/magnum-v4-72b": {
@@ -24574,12 +18635,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -24597,13 +18654,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -24621,23 +18673,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5.1": {
@@ -24655,23 +18695,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -24692,14 +18720,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -24720,14 +18742,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -24748,14 +18764,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -24776,14 +18786,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -24801,23 +18805,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -24835,24 +18828,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -24870,24 +18851,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5": {
@@ -24905,24 +18874,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -24943,14 +18900,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -24971,14 +18922,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -24996,23 +18941,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -25030,24 +18964,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -25064,12 +18986,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "baidu/ernie-4.5-vl-424b-a47b": {
@@ -25090,13 +19008,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-1.6": {
@@ -25116,14 +19029,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-1.6-flash": {
@@ -25143,14 +19050,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2-1-turbo": {
@@ -25170,14 +19071,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-code": {
@@ -25194,22 +19089,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-lite": {
@@ -25226,23 +19111,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "bytedance-seed/seed-2.0-mini": {
@@ -25259,23 +19133,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "bytedance/ui-tars-1.5-7b": {
@@ -25293,13 +19156,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -25317,12 +19175,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-a": {
@@ -25340,12 +19194,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r-08-2024": {
@@ -25363,12 +19213,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r-plus-08-2024": {
@@ -25386,12 +19232,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/command-r7b-12-2024": {
@@ -25409,12 +19251,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/north-mini-code:free": {
@@ -25435,12 +19273,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat": {
@@ -25458,12 +19292,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat-v3-0324": {
@@ -25481,12 +19311,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat-v3.1": {
@@ -25507,12 +19333,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1": {
@@ -25530,12 +19352,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1-0528": {
@@ -25553,12 +19371,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1-distill-llama-70b": {
@@ -25579,12 +19393,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -25605,12 +19415,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -25631,12 +19437,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -25657,12 +19459,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -25680,19 +19478,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -25710,20 +19501,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -25740,21 +19523,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -25772,19 +19546,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -25801,20 +19568,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4.1-flash": {
@@ -25832,21 +19591,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -25867,13 +19617,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -25894,16 +19639,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -25921,14 +19658,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -25949,16 +19680,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -25976,16 +19699,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro-preview": {
@@ -26003,15 +19718,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro-preview-05-06": {
@@ -26029,16 +19737,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio", "video"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -26056,25 +19756,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-pro-image": {
@@ -26092,14 +19779,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3-pro-image-preview": {
@@ -26117,14 +19798,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -26142,21 +19817,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -26174,21 +19840,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["image", "text"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -26206,25 +19863,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -26242,21 +19886,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ],
+            "efforts": ["minimal", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -26274,25 +19909,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -26310,23 +19932,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview-customtools": {
@@ -26344,23 +19954,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -26378,24 +19976,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -26413,24 +19998,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.6-flash": {
@@ -26448,24 +20020,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.7-flash": {
@@ -26483,23 +20042,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.8-flash": {
@@ -26516,23 +20063,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-2-27b-it": {
@@ -26550,12 +20085,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-12b-it": {
@@ -26573,13 +20104,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-27b-it": {
@@ -26597,13 +20123,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-3-4b-it": {
@@ -26621,13 +20142,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -26647,14 +20163,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it:free": {
@@ -26675,14 +20185,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -26702,14 +20206,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it:free": {
@@ -26730,14 +20228,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "google/lyria-3-clip-preview": {
@@ -26755,14 +20247,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "google/lyria-3-pro-preview": {
@@ -26780,14 +20266,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "audio"]
           }
         },
         "gryphe/mythomax-l2-13b": {
@@ -26805,12 +20285,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ibm-granite/granite-4.0-h-micro": {
@@ -26827,12 +20303,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ibm-granite/granite-4.2-8b": {
@@ -26849,19 +20321,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-2": {
@@ -26878,20 +20342,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-2.5": {
@@ -26908,20 +20363,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -26941,12 +20387,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin": {
@@ -26966,12 +20408,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin:free": {
@@ -26992,12 +20430,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-sante:free": {
@@ -27018,12 +20452,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-vl": {
@@ -27043,14 +20473,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-vl:free": {
@@ -27071,14 +20495,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "inference-net/schematron-v2-small": {
@@ -27095,12 +20513,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inference-net/schematron-v2-turbo": {
@@ -27117,12 +20531,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -27139,12 +20549,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -27161,12 +20567,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "liquid/lfm-2.5-2.6b:free": {
@@ -27184,12 +20586,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mancer/weaver": {
@@ -27207,12 +20605,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meituan/longcat-2.0": {
@@ -27232,12 +20626,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.1-70b-instruct": {
@@ -27255,12 +20645,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.1-8b-instruct": {
@@ -27278,12 +20664,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.2-1b-instruct": {
@@ -27301,12 +20683,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.2-3b-instruct": {
@@ -27324,12 +20702,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-3.3-70b-instruct": {
@@ -27347,12 +20721,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -27370,13 +20740,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-4-scout": {
@@ -27394,13 +20759,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta-llama/llama-guard-4-12b": {
@@ -27418,13 +20778,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -27442,21 +20797,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.1": {
@@ -27473,25 +20818,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2": {
@@ -27508,25 +20839,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -27543,25 +20860,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.3": {
@@ -27578,26 +20881,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.3-contributor": {
@@ -27614,26 +20902,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "microsoft/phi-4": {
@@ -27651,12 +20924,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "microsoft/wizardlm-2-8x22b": {
@@ -27674,12 +20943,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-01": {
@@ -27697,13 +20962,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m1": {
@@ -27724,12 +20984,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2": {
@@ -27746,12 +21002,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2-her": {
@@ -27768,12 +21020,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -27790,12 +21038,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -27812,12 +21056,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -27834,12 +21074,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -27859,14 +21095,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "mistralai/codestral-2508": {
@@ -27884,13 +21114,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/devstral-2512": {
@@ -27908,13 +21133,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-14b-2512": {
@@ -27931,13 +21151,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-3b-2512": {
@@ -27954,13 +21169,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/ministral-8b-2512": {
@@ -27977,13 +21187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large": {
@@ -28001,13 +21206,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-2407": {
@@ -28025,13 +21225,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-large-2512": {
@@ -28049,14 +21244,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3": {
@@ -28074,14 +21263,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3-5": {
@@ -28098,20 +21281,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-medium-3.1": {
@@ -28129,14 +21303,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-nemo": {
@@ -28154,12 +21322,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-saba": {
@@ -28177,13 +21341,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-24b-instruct-2501": {
@@ -28201,12 +21360,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-2603": {
@@ -28224,19 +21379,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-3.1-24b-instruct": {
@@ -28254,13 +21401,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistralai/mistral-small-3.2-24b-instruct": {
@@ -28278,13 +21420,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "mistralai/mixtral-8x22b-instruct": {
@@ -28302,13 +21439,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "mistralai/voxtral-small-24b-2507": {
@@ -28325,14 +21457,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2": {
@@ -28350,12 +21476,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -28373,12 +21495,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -28396,12 +21514,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -28422,13 +21536,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -28449,13 +21558,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -28473,13 +21577,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -28496,22 +21595,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-fast": {
@@ -28528,12 +21617,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-large": {
@@ -28550,12 +21635,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nex-agi/nex-n2.5-mini:free": {
@@ -28573,20 +21654,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nex-agi/nex-n2.5-pro:free": {
@@ -28604,20 +21676,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-3-llama-3.1-405b": {
@@ -28635,12 +21698,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-3-llama-3.1-70b": {
@@ -28658,12 +21717,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nousresearch/hermes-4-405b": {
@@ -28684,12 +21739,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -28709,12 +21760,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -28735,15 +21782,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -28760,19 +21800,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium"
-            ],
+            "efforts": ["low", "medium"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b:free": {
@@ -28790,19 +21823,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium"
-            ],
+            "efforts": ["low", "medium"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -28819,19 +21845,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high"
-            ],
+            "efforts": ["medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -28849,19 +21868,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high"
-            ],
+            "efforts": ["medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-content-safety": {
@@ -28881,13 +21893,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-content-safety:free": {
@@ -28908,13 +21915,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -28934,12 +21936,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning:free": {
@@ -28960,12 +21958,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -28983,12 +21977,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-0613": {
@@ -29006,12 +21996,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-16k": {
@@ -29029,12 +22015,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo-instruct": {
@@ -29052,12 +22034,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4": {
@@ -29075,12 +22053,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo": {
@@ -29098,13 +22072,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo-preview": {
@@ -29122,12 +22091,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1": {
@@ -29145,14 +22110,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -29170,14 +22129,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -29195,14 +22148,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o": {
@@ -29220,14 +22167,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-05-13": {
@@ -29245,14 +22186,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-08-06": {
@@ -29270,14 +22205,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-2024-11-20": {
@@ -29295,14 +22224,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini": {
@@ -29320,14 +22243,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-2024-07-18": {
@@ -29345,14 +22262,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -29371,22 +22282,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-image": {
@@ -29404,15 +22304,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5-image-mini": {
@@ -29429,15 +22322,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5-mini": {
@@ -29456,22 +22342,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-nano": {
@@ -29490,22 +22365,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-pro": {
@@ -29524,19 +22388,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1": {
@@ -29555,22 +22411,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -29589,20 +22434,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -29621,21 +22457,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -29654,21 +22480,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -29687,23 +22504,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-chat": {
@@ -29721,14 +22526,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -29747,21 +22546,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -29780,21 +22569,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -29813,23 +22592,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -29848,23 +22615,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-image-2": {
@@ -29881,24 +22636,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["image", "text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -29917,23 +22659,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -29952,23 +22682,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -29987,21 +22705,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -30020,23 +22728,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -30055,21 +22751,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -30088,24 +22774,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna-pro": {
@@ -30124,24 +22797,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -30160,24 +22820,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol-pro": {
@@ -30196,24 +22843,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -30232,24 +22866,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra-pro": {
@@ -30268,24 +22889,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-6-astra": {
@@ -30304,23 +22912,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-6-astra-pro": {
@@ -30337,23 +22933,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-audio": {
@@ -30370,14 +22954,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-audio-mini": {
@@ -30394,14 +22972,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-chat-latest": {
@@ -30418,14 +22990,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -30442,19 +23008,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -30471,19 +23029,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -30500,19 +23050,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/o1": {
@@ -30533,14 +23075,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o1-pro": {
@@ -30561,14 +23097,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3": {
@@ -30589,14 +23119,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini": {
@@ -30617,13 +23141,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini-high": {
@@ -30641,18 +23160,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-pro": {
@@ -30673,14 +23185,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "pdf",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "pdf", "image"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini": {
@@ -30701,14 +23207,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini-high": {
@@ -30726,19 +23226,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openrouter/auto": {
@@ -30755,17 +23247,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf",
-              "video"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "audio", "pdf", "video"],
+            "output": ["text", "image"]
           }
         },
         "openrouter/bodybuilder": {
@@ -30782,12 +23265,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openrouter/free": {
@@ -30806,13 +23285,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openrouter/fusion": {
@@ -30829,12 +23303,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openrouter/pareto-code": {
@@ -30851,12 +23321,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perceptron/perceptron-mk1": {
@@ -30876,14 +23342,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar": {
@@ -30900,13 +23360,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-deep-research": {
@@ -30926,12 +23381,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro": {
@@ -30948,13 +23399,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro-search": {
@@ -30971,13 +23417,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -30997,13 +23438,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -31023,12 +23459,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1:free": {
@@ -31049,12 +23481,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1": {
@@ -31074,12 +23502,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-xs-2.1:free": {
@@ -31100,12 +23524,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-72b-instruct": {
@@ -31123,12 +23543,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-7b-instruct": {
@@ -31146,12 +23562,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-2.5-coder-32b-instruct": {
@@ -31169,12 +23581,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-plus": {
@@ -31192,12 +23600,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen-plus-2025-07-28": {
@@ -31215,12 +23619,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen2.5-vl-72b-instruct": {
@@ -31238,13 +23638,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-14b": {
@@ -31265,12 +23660,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b": {
@@ -31291,12 +23682,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b-2507": {
@@ -31314,12 +23701,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-235b-a22b-thinking-2507": {
@@ -31337,12 +23720,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b": {
@@ -31362,12 +23741,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b-instruct-2507": {
@@ -31385,12 +23760,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-30b-a3b-thinking-2507": {
@@ -31408,12 +23779,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-32b": {
@@ -31434,12 +23801,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-8b": {
@@ -31460,12 +23823,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder": {
@@ -31483,12 +23842,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-30b-a3b-instruct": {
@@ -31506,12 +23861,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-flash": {
@@ -31529,12 +23880,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-next": {
@@ -31552,12 +23899,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -31575,12 +23918,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max": {
@@ -31598,12 +23937,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max-thinking": {
@@ -31623,12 +23958,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-instruct": {
@@ -31646,12 +23977,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-next-80b-a3b-thinking": {
@@ -31669,12 +23996,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-235b-a22b-instruct": {
@@ -31692,13 +24015,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-235b-a22b-thinking": {
@@ -31716,13 +24034,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-30b-a3b-instruct": {
@@ -31740,13 +24053,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-30b-a3b-thinking": {
@@ -31764,13 +24072,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-32b-instruct": {
@@ -31787,13 +24090,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-8b-instruct": {
@@ -31810,13 +24108,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-vl-8b-thinking": {
@@ -31833,13 +24126,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-122b-a10b": {
@@ -31859,14 +24147,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-27b": {
@@ -31886,14 +24168,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-35b-a3b": {
@@ -31913,14 +24189,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-397b-a17b": {
@@ -31940,14 +24210,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-9b": {
@@ -31967,14 +24231,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-flash-02-23": {
@@ -31994,14 +24252,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus-02-15": {
@@ -32022,14 +24274,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus-20260420": {
@@ -32049,14 +24295,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-27b": {
@@ -32076,14 +24316,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-35b-a3b": {
@@ -32103,14 +24337,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-flash": {
@@ -32130,14 +24358,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-max-preview": {
@@ -32158,12 +24380,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -32184,14 +24402,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-flash": {
@@ -32212,14 +24424,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-max": {
@@ -32239,12 +24445,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -32265,13 +24467,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-2.4t-a95b": {
@@ -32288,19 +24485,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-27b": {
@@ -32317,22 +24506,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-flash": {
@@ -32352,14 +24531,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.8-max-0902": {
@@ -32376,23 +24549,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "rekaai/reka-edge": {
@@ -32409,14 +24570,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         },
         "rekaai/reka-flash-3": {
@@ -32434,12 +24589,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "relace/relace-apply-3": {
@@ -32456,12 +24607,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "relace/relace-search": {
@@ -32478,12 +24625,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sakana/fugu-max": {
@@ -32500,21 +24643,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "sakana/fugu-ultra": {
@@ -32531,20 +24664,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sakana/fugu-ultra-v2": {
@@ -32562,21 +24686,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "sakana/sakana-namazu": {
@@ -32593,20 +24707,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "sao10k/l3-lunaris-8b": {
@@ -32624,12 +24729,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sao10k/l3.1-euryale-70b": {
@@ -32647,12 +24748,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "sao10k/l3.3-euryale-70b": {
@@ -32670,12 +24767,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -32693,12 +24786,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -32717,21 +24806,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "tencent/hunyuan-a13b-instruct": {
@@ -32752,12 +24831,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-1.8b": {
@@ -32774,12 +24849,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-30b-a3b": {
@@ -32796,12 +24867,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-7b": {
@@ -32818,12 +24885,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3": {
@@ -32841,19 +24904,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3-preview": {
@@ -32870,19 +24925,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy4-preview": {
@@ -32899,19 +24946,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/cydonia-24b-v4.1": {
@@ -32929,12 +24968,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/skyfall-36b-v2": {
@@ -32952,12 +24987,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thedrummer/unslopnemo-12b": {
@@ -32975,12 +25006,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -32997,24 +25024,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -33031,24 +25045,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small:free": {
@@ -33066,24 +25067,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling:free": {
@@ -33101,24 +25089,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "undi95/remm-slerp-l2-13b": {
@@ -33136,12 +25111,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "upstage/solar-pro-3": {
@@ -33161,12 +25132,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "upstage/solar-pro4": {
@@ -33186,12 +25153,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "writer/palmyra-x5": {
@@ -33208,12 +25171,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.20": {
@@ -33234,14 +25193,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.20-multi-agent": {
@@ -33259,22 +25212,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.3": {
@@ -33291,22 +25233,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.5": {
@@ -33323,21 +25254,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.6": {
@@ -33355,22 +25276,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -33387,14 +25297,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -33415,15 +25319,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -33444,12 +25341,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5": {
@@ -33470,12 +25363,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -33496,12 +25385,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5v": {
@@ -33522,13 +25407,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6": {
@@ -33549,12 +25429,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v": {
@@ -33575,14 +25451,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7": {
@@ -33603,12 +25473,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flash": {
@@ -33629,12 +25495,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5": {
@@ -33654,12 +25516,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -33679,12 +25537,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.1": {
@@ -33704,12 +25558,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -33726,19 +25576,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.3": {
@@ -33755,19 +25598,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.3-flash": {
@@ -33784,21 +25619,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -33818,14 +25643,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -33844,12 +25663,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "ByteDance-Seed/Seed-OSS-36B-Instruct": {
@@ -33866,12 +25681,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -33888,12 +25699,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -33910,12 +25717,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1": {
@@ -33935,12 +25738,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.1-Terminus": {
@@ -33960,12 +25759,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2": {
@@ -33985,12 +25780,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3.2-Exp": {
@@ -34010,12 +25801,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash": {
@@ -34033,12 +25820,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -34056,12 +25839,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26B-A4B-it": {
@@ -34078,12 +25857,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -34100,12 +25875,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionAI/Ling-flash-2.0": {
@@ -34122,12 +25893,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -34144,12 +25911,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -34166,13 +25929,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -34189,13 +25947,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -34212,12 +25965,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -34234,12 +25983,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-72B-Instruct": {
@@ -34256,12 +26001,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct": {
@@ -34278,12 +26019,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-14B": {
@@ -34303,12 +26040,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -34325,12 +26058,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-30B-A3B-Instruct-2507": {
@@ -34347,12 +26076,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-32B": {
@@ -34372,12 +26097,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-8B": {
@@ -34397,12 +26118,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
@@ -34419,12 +26136,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
@@ -34441,12 +26154,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Instruct": {
@@ -34463,13 +26172,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-235B-A22B-Thinking": {
@@ -34486,13 +26190,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Instruct": {
@@ -34509,13 +26208,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-30B-A3B-Thinking": {
@@ -34532,13 +26226,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-32B-Instruct": {
@@ -34555,13 +26244,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-32B-Thinking": {
@@ -34578,13 +26262,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-VL-8B-Instruct": {
@@ -34601,13 +26280,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-122B-A10B": {
@@ -34624,12 +26298,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-27B": {
@@ -34646,12 +26316,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-35B-A3B": {
@@ -34668,12 +26334,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -34690,12 +26352,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -34712,12 +26370,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-27B": {
@@ -34734,12 +26388,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-35B-A3B": {
@@ -34756,12 +26406,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun-ai/Step-3.5-Flash": {
@@ -34778,12 +26424,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/Hunyuan-A13B-Instruct": {
@@ -34803,12 +26445,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/Hy3-preview": {
@@ -34824,12 +26462,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-4.5-Air": {
@@ -34846,12 +26480,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -34868,12 +26498,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -34890,12 +26516,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -34912,18 +26534,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5V-Turbo": {
@@ -34942,13 +26557,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         }
       },
@@ -34968,12 +26578,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-2-16k": {
@@ -34991,12 +26597,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash": {
@@ -35014,18 +26616,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35043,18 +26638,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35072,21 +26660,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "step-tts-2": {
@@ -35102,12 +26680,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "stepaudio-2.5-asr": {
@@ -35123,12 +26697,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "stepaudio-2.5-tts": {
@@ -35144,12 +26714,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -35169,12 +26735,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-2-16k": {
@@ -35192,12 +26754,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash": {
@@ -35215,18 +26773,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35244,18 +26795,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35273,21 +26817,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "step-tts-2": {
@@ -35303,12 +26837,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "stepaudio-2.5-asr": {
@@ -35324,12 +26854,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "stepaudio-2.5-tts": {
@@ -35345,12 +26871,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -35370,18 +26892,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35399,18 +26914,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35428,21 +26936,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -35462,18 +26960,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.5-flash-2603": {
@@ -35491,18 +26982,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high"
-            ]
+            "efforts": ["low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "step-3.7-flash": {
@@ -35520,21 +27004,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "step-router-v1": {
@@ -35552,12 +27026,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -35578,12 +27048,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-R1": {
@@ -35600,12 +27066,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3": {
@@ -35622,12 +27084,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V3-1": {
@@ -35647,12 +27105,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Flash-0731": {
@@ -35670,19 +27124,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro": {
@@ -35699,19 +27146,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek-ai/DeepSeek-V4-Pro-0813": {
@@ -35728,20 +27168,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ],
+            "efforts": ["low", "high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "essentialai/Rnj-1-Instruct": {
@@ -35758,12 +27190,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-3n-E4B-it": {
@@ -35780,12 +27208,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31B-it": {
@@ -35803,13 +27227,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "LiquidAI/LFM2-24B-A2B": {
@@ -35825,12 +27244,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -35847,12 +27262,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
@@ -35868,12 +27279,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.5": {
@@ -35889,12 +27296,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M2.7": {
@@ -35911,12 +27314,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "MiniMaxAI/MiniMax-M3": {
@@ -35933,13 +27332,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.5": {
@@ -35959,13 +27353,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.6": {
@@ -35986,14 +27375,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K2.7-Code": {
@@ -36010,12 +27393,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/Kimi-K3": {
@@ -36032,21 +27411,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -36066,12 +27435,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -36088,19 +27453,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -36117,19 +27474,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "pearl-ai/gemma-4-31b-it": {
@@ -36145,12 +27494,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen2.5-7B-Instruct-Turbo": {
@@ -36167,12 +27512,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
@@ -36189,12 +27530,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -36211,12 +27548,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3-Coder-Next-FP8": {
@@ -36233,12 +27566,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-397B-A17B": {
@@ -36257,13 +27586,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.5-9B": {
@@ -36283,13 +27607,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.6-Plus": {
@@ -36308,12 +27627,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "Qwen/Qwen3.7-Max": {
@@ -36329,12 +27644,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/Inkling": {
@@ -36351,24 +27662,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max",
-              "xhigh",
-              "high",
-              "medium",
-              "low",
-              "none"
-            ]
+            "efforts": ["max", "xhigh", "high", "medium", "low", "none"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5": {
@@ -36388,12 +27686,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.1": {
@@ -36414,12 +27708,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.2": {
@@ -36436,19 +27726,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ],
+            "efforts": ["high", "max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3": {
@@ -36465,19 +27748,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai-org/GLM-5.3-Flash": {
@@ -36494,21 +27769,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         }
       },
@@ -36530,12 +27795,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-2.0-instruct": {
@@ -36552,12 +27813,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-2.0-thinking": {
@@ -36574,12 +27831,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-t1": {
@@ -36596,12 +27849,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hunyuan-turbos": {
@@ -36618,12 +27867,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kimi-k2.5": {
@@ -36644,14 +27889,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "minimax-m2.5": {
@@ -36668,12 +27907,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tc-code-latest": {
@@ -36690,12 +27925,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36715,19 +27946,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -36743,19 +27967,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36775,19 +27992,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy3-preview": {
@@ -36804,20 +28014,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "hy4-preview": {
@@ -36833,19 +28035,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ],
+            "efforts": ["none", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -36867,12 +28062,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-235b": {
@@ -36889,12 +28080,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-30b": {
@@ -36914,12 +28101,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3-32b": {
@@ -36939,12 +28122,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen-3.6-max-preview": {
@@ -36963,12 +28142,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-235b-a22b-thinking": {
@@ -36985,14 +28160,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder": {
@@ -37009,12 +28178,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-30b-a3b": {
@@ -37031,12 +28196,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-next": {
@@ -37054,12 +28215,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-coder-plus": {
@@ -37076,12 +28233,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-0.6b": {
@@ -37097,12 +28250,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-4b": {
@@ -37118,12 +28267,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-embedding-8b": {
@@ -37139,12 +28284,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max": {
@@ -37161,12 +28302,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max-preview": {
@@ -37183,12 +28320,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-max-thinking": {
@@ -37205,12 +28338,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-next-80b-a3b-instruct": {
@@ -37227,12 +28356,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-next-80b-a3b-thinking": {
@@ -37249,12 +28374,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-235b-a22b-instruct": {
@@ -37272,13 +28393,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-instruct": {
@@ -37295,13 +28411,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3-vl-thinking": {
@@ -37318,14 +28429,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.5-flash": {
@@ -37345,14 +28450,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.5-plus": {
@@ -37372,14 +28471,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.6-27b": {
@@ -37399,14 +28492,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.6-plus": {
@@ -37426,14 +28513,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-flash": {
@@ -37450,14 +28531,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-max": {
@@ -37476,12 +28551,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.7-plus": {
@@ -37501,14 +28572,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-2.4t-a95b": {
@@ -37525,20 +28590,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-27b": {
@@ -37555,22 +28611,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-flash": {
@@ -37590,14 +28635,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-flash-next": {
@@ -37614,20 +28653,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-max": {
@@ -37643,20 +28673,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "alibaba/qwen3.8-max-0902": {
@@ -37672,22 +28693,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "alibaba/wan-v2.5-t2v-preview": {
@@ -37703,12 +28714,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.6-i2v": {
@@ -37724,12 +28731,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.6-i2v-flash": {
@@ -37745,12 +28748,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.6-r2v": {
@@ -37766,12 +28765,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.6-r2v-flash": {
@@ -37787,12 +28782,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.6-t2v": {
@@ -37808,12 +28799,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.7-r2v": {
@@ -37829,12 +28816,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v2.7-t2v": {
@@ -37850,12 +28833,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v3.0-video": {
@@ -37871,13 +28850,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "alibaba/wan-v3.0-video-prime": {
@@ -37893,13 +28867,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "amazon/nova-2-lite": {
@@ -37916,22 +28885,12 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/nova-lite": {
@@ -37948,15 +28907,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/nova-micro": {
@@ -37973,12 +28925,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "amazon/nova-pro": {
@@ -37995,15 +28943,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "amazon/titan-embed-text-v2": {
@@ -38019,12 +28960,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3-haiku": {
@@ -38041,13 +28978,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -38064,23 +28996,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5.1": {
@@ -38097,23 +29018,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -38133,14 +29042,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -38157,14 +29060,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -38184,14 +29081,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -38208,22 +29099,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -38240,23 +29121,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -38273,23 +29143,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8-fast": {
@@ -38306,23 +29165,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5": {
@@ -38339,23 +29187,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-5-fast": {
@@ -38372,23 +29208,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -38405,14 +29229,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -38430,14 +29248,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -38454,22 +29266,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -38486,23 +29288,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["low", "medium", "high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "arcee-ai/trinity-large-thinking": {
@@ -38518,12 +29309,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "bfl/flux-2-flex": {
@@ -38539,12 +29326,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-klein-4b": {
@@ -38560,12 +29343,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-klein-9b": {
@@ -38581,12 +29360,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-max": {
@@ -38602,12 +29377,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-2-pro": {
@@ -38623,12 +29394,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-3-video": {
@@ -38644,12 +29411,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "bfl/flux-kontext-max": {
@@ -38665,12 +29428,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-kontext-pro": {
@@ -38686,12 +29445,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.0-fill": {
@@ -38707,12 +29462,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.1": {
@@ -38728,12 +29479,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bfl/flux-pro-1.1-ultra": {
@@ -38749,12 +29496,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seed-1.6": {
@@ -38774,13 +29517,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance/seed-1.8": {
@@ -38797,22 +29535,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["minimal", "low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "bytedance/seedance-2.0": {
@@ -38828,13 +29556,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-2.0-fast": {
@@ -38850,13 +29573,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-2.0-mini": {
@@ -38872,13 +29590,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-2.5": {
@@ -38894,12 +29607,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-v1.0-pro": {
@@ -38915,12 +29624,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-v1.0-pro-fast": {
@@ -38936,12 +29641,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "bytedance/seedance-v1.5-pro": {
@@ -38957,12 +29658,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "bytedance/seedream-4.0": {
@@ -38978,12 +29675,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-4.5": {
@@ -38999,12 +29692,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-5.0-lite": {
@@ -39020,12 +29709,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "bytedance/seedream-5.0-pro": {
@@ -39041,12 +29726,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "cohere/command-a": {
@@ -39063,12 +29744,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/embed-v4.0": {
@@ -39084,12 +29761,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v3.5": {
@@ -39105,12 +29778,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v4-fast": {
@@ -39126,12 +29795,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "cohere/rerank-v4-pro": {
@@ -39147,12 +29812,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-r1": {
@@ -39169,12 +29830,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1": {
@@ -39193,12 +29850,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.1-terminus": {
@@ -39218,12 +29871,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -39241,12 +29890,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-thinking": {
@@ -39263,12 +29908,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -39286,19 +29927,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -39316,12 +29950,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
@@ -39338,20 +29968,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -39369,19 +29991,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
@@ -39398,19 +30013,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4.1-flash": {
@@ -39428,20 +30036,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "fish-audio/s1": {
@@ -39457,12 +30057,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s1-free": {
@@ -39478,12 +30074,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2-pro": {
@@ -39499,12 +30091,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2-pro-free": {
@@ -39520,12 +30108,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2.1-pro": {
@@ -39541,12 +30125,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/s2.1-pro-free": {
@@ -39562,12 +30142,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "fish-audio/transcribe-1": {
@@ -39583,12 +30159,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "fish-audio/transcribe-1-free": {
@@ -39604,12 +30176,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -39630,16 +30198,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-image": {
@@ -39656,14 +30216,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -39684,14 +30238,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -39709,16 +30257,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash": {
@@ -39735,22 +30275,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-pro-image": {
@@ -39767,14 +30296,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image": {
@@ -39791,20 +30314,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-image-preview": {
@@ -39821,20 +30335,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "high"
-            ]
+            "efforts": ["minimal", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -39852,22 +30357,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-image": {
@@ -39885,14 +30379,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["text", "image"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -39910,21 +30398,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -39942,22 +30420,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash-lite": {
@@ -39975,22 +30442,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-transcribe": {
@@ -40006,12 +30462,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-transcribe-live": {
@@ -40027,12 +30479,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.6-flash": {
@@ -40050,22 +30498,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.7-flash": {
@@ -40083,21 +30520,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.8-flash": {
@@ -40114,14 +30541,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-embedding-001": {
@@ -40138,12 +30559,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-embedding-2": {
@@ -40160,12 +30577,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-omni-flash-preview": {
@@ -40181,14 +30594,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-26b-a4b-it": {
@@ -40205,14 +30612,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemma-4-31b-it": {
@@ -40229,14 +30630,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "google/text-embedding-005": {
@@ -40252,12 +30647,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/text-multilingual-embedding-002": {
@@ -40273,12 +30664,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/veo-3.0-fast-generate-001": {
@@ -40294,12 +30681,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "google/veo-3.0-generate-001": {
@@ -40315,12 +30698,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "google/veo-3.1-fast-generate-001": {
@@ -40336,12 +30715,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "google/veo-3.1-generate-001": {
@@ -40357,12 +30732,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "google/veo-3.1-lite-generate-001": {
@@ -40378,12 +30749,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "inception/mercury-2": {
@@ -40399,19 +30766,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-2.5": {
@@ -40427,20 +30786,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inception/mercury-coder-small": {
@@ -40456,12 +30806,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash": {
@@ -40477,12 +30823,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin": {
@@ -40502,12 +30844,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-fin-free": {
@@ -40527,12 +30865,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-sante": {
@@ -40549,12 +30883,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-3.0-flash-sante-free": {
@@ -40571,12 +30901,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "interfaze/interfaze-beta": {
@@ -40592,21 +30918,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "klingai/kling-v2.5-turbo-i2v": {
@@ -40622,12 +30938,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v2.5-turbo-t2v": {
@@ -40643,12 +30955,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v2.6-i2v": {
@@ -40664,12 +30972,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v2.6-motion-control": {
@@ -40685,12 +30989,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v2.6-t2v": {
@@ -40706,12 +31006,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v3.0-i2v": {
@@ -40727,12 +31023,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v3.0-motion-control": {
@@ -40748,12 +31040,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "klingai/kling-v3.0-t2v": {
@@ -40769,12 +31057,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "kwaipilot/kat-coder-air-v2.5": {
@@ -40790,13 +31074,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v1": {
@@ -40813,12 +31092,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2": {
@@ -40834,12 +31109,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kwaipilot/kat-coder-pro-v2.5": {
@@ -40855,13 +31126,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-70b": {
@@ -40878,12 +31144,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.1-8b": {
@@ -40900,12 +31162,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-3.3-70b": {
@@ -40923,12 +31181,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-maverick": {
@@ -40946,13 +31200,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/llama-4-scout": {
@@ -40970,13 +31219,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-glimmer-30b": {
@@ -40994,21 +31238,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "meta/muse-image-1.0": {
@@ -41024,13 +31258,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text", "image"],
+            "output": ["image"]
           }
         },
         "meta/muse-spark-1.1": {
@@ -41047,23 +31276,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2": {
@@ -41080,14 +31297,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.2-contributor": {
@@ -41103,14 +31314,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.3": {
@@ -41127,24 +31332,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "meta/muse-spark-1.3-contributor": {
@@ -41160,14 +31352,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-h3": {
@@ -41183,13 +31369,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "minimax/minimax-h3-max": {
@@ -41205,13 +31386,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image"],
+            "output": ["video"]
           }
         },
         "minimax/minimax-m2": {
@@ -41228,12 +31404,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -41249,12 +31421,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1-lightning": {
@@ -41271,12 +31439,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -41292,12 +31456,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5-highspeed": {
@@ -41313,12 +31473,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -41334,12 +31490,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -41355,12 +31507,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -41379,14 +31527,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistral/codestral": {
@@ -41403,12 +31545,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/codestral-embed": {
@@ -41424,12 +31562,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/devstral-2": {
@@ -41446,12 +31580,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/devstral-small-2": {
@@ -41468,13 +31598,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-14b": {
@@ -41491,14 +31616,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-3b": {
@@ -41515,12 +31634,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/ministral-8b": {
@@ -41537,12 +31652,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-embed": {
@@ -41558,12 +31669,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-large-3": {
@@ -41580,13 +31687,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-medium": {
@@ -41603,13 +31705,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-medium-3.5": {
@@ -41625,19 +31722,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-nemo": {
@@ -41654,13 +31743,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/mistral-small": {
@@ -41677,13 +31761,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "mistral/pixtral-12b": {
@@ -41700,13 +31779,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2": {
@@ -41722,12 +31796,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -41744,12 +31814,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -41770,13 +31836,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -41797,13 +31858,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -41821,14 +31877,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code-highspeed": {
@@ -41846,14 +31896,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -41870,14 +31914,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3-fast": {
@@ -41894,21 +31932,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-fast": {
@@ -41924,12 +31952,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "morph/morph-v3-large": {
@@ -41945,12 +31969,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-nano-30b-a3b": {
@@ -41969,12 +31989,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-super-120b-a12b": {
@@ -41993,12 +32009,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -42017,12 +32029,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-3.5-lightning": {
@@ -42042,12 +32050,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-12b-v2-vl": {
@@ -42066,13 +32070,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "nvidia/nemotron-nano-9b-v2": {
@@ -42091,12 +32090,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-3.5-turbo": {
@@ -42115,12 +32110,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4-turbo": {
@@ -42138,13 +32129,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1": {
@@ -42162,14 +32148,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-fast": {
@@ -42188,14 +32168,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini": {
@@ -42213,14 +32187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-mini-fast": {
@@ -42239,14 +32207,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano": {
@@ -42264,13 +32226,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4.1-nano-fast": {
@@ -42289,14 +32246,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o": {
@@ -42314,14 +32265,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-fast": {
@@ -42340,14 +32285,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini": {
@@ -42365,14 +32304,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-fast": {
@@ -42391,14 +32324,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-mini-transcribe": {
@@ -42414,12 +32341,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-4o-transcribe": {
@@ -42435,12 +32358,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -42459,21 +32378,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-codex": {
@@ -42492,21 +32401,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-fast": {
@@ -42525,22 +32424,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-mini": {
@@ -42559,21 +32447,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-mini-fast": {
@@ -42592,22 +32470,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-nano": {
@@ -42626,21 +32493,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-pro": {
@@ -42659,19 +32516,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high"
-            ]
+            "efforts": ["high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -42690,21 +32539,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-max": {
@@ -42723,22 +32562,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -42757,21 +32585,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-thinking": {
@@ -42789,23 +32607,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text",
-              "image"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "image"]
           }
         },
         "openai/gpt-5.1-thinking-fast": {
@@ -42822,14 +32628,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -42848,23 +32648,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -42883,22 +32671,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-fast": {
@@ -42917,23 +32694,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -42952,21 +32717,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -42985,22 +32740,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex-fast": {
@@ -43019,22 +32763,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -43053,23 +32786,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-fast": {
@@ -43088,23 +32809,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -43123,23 +32832,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini-fast": {
@@ -43158,23 +32855,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -43193,23 +32878,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -43228,21 +32901,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -43261,23 +32924,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-fast": {
@@ -43296,23 +32947,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -43331,21 +32970,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -43364,24 +32993,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna-fast": {
@@ -43400,24 +33016,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -43436,24 +33039,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol-fast": {
@@ -43472,24 +33062,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -43508,24 +33085,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra-fast": {
@@ -43544,24 +33108,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-6-astra": {
@@ -43580,24 +33131,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-6-astra-fast": {
@@ -43615,24 +33153,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-image-1": {
@@ -43648,12 +33173,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-1-mini": {
@@ -43669,12 +33190,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-1.5": {
@@ -43690,12 +33207,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-2": {
@@ -43711,12 +33224,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-2.5-flare": {
@@ -43732,12 +33241,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-image-2.5-sunburst": {
@@ -43753,12 +33258,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "openai/gpt-oss-120b": {
@@ -43776,19 +33277,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-20b": {
@@ -43807,19 +33300,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-120b": {
@@ -43837,19 +33322,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-oss-safeguard-20b": {
@@ -43867,19 +33344,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-realtime-1.5": {
@@ -43895,14 +33364,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-2": {
@@ -43918,14 +33381,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-2.1": {
@@ -43944,23 +33401,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["minimal", "low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-mini": {
@@ -43976,14 +33421,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "openai/gpt-realtime-whisper": {
@@ -43999,12 +33438,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "openai/o1": {
@@ -44022,21 +33457,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3": {
@@ -44054,21 +33479,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-fast": {
@@ -44087,21 +33502,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o3-mini": {
@@ -44119,19 +33524,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/o3-pro": {
@@ -44150,21 +33547,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini": {
@@ -44182,20 +33569,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/o4-mini-fast": {
@@ -44214,21 +33592,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-3-large": {
@@ -44245,12 +33613,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-3-small": {
@@ -44267,12 +33631,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/text-embedding-ada-002": {
@@ -44289,12 +33649,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/tts-1": {
@@ -44310,12 +33666,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "openai/tts-1-hd": {
@@ -44331,12 +33683,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "openai/whisper-1": {
@@ -44352,12 +33700,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "perplexity/pplx-embed-v1-0.6b": {
@@ -44373,12 +33717,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/pplx-embed-v1-4b": {
@@ -44394,12 +33734,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar": {
@@ -44416,13 +33752,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-pro": {
@@ -44439,13 +33770,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "perplexity/sonar-reasoning-pro": {
@@ -44462,21 +33788,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "minimal",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["minimal", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1": {
@@ -44496,12 +33812,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "poolside/laguna-s-2.1-free": {
@@ -44522,12 +33834,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "prodia/flux-fast-schnell": {
@@ -44543,12 +33851,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "quiverai/arrow-1.1": {
@@ -44564,12 +33868,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v2": {
@@ -44585,12 +33885,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v3": {
@@ -44606,12 +33902,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4": {
@@ -44627,12 +33919,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4-pro": {
@@ -44648,12 +33936,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1": {
@@ -44669,12 +33953,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-pro": {
@@ -44690,12 +33970,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-utility": {
@@ -44711,12 +33987,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "recraft/recraft-v4.1-utility-pro": {
@@ -44732,12 +34004,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "sakana/fugu-ultra": {
@@ -44754,13 +34022,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sakana/namazu": {
@@ -44776,14 +34039,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.1-fast-non-reasoning": {
@@ -44799,14 +34056,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.1-fast-reasoning": {
@@ -44822,14 +34073,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-multi-agent": {
@@ -44845,14 +34090,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-multi-agent-beta": {
@@ -44868,14 +34107,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-non-reasoning": {
@@ -44891,14 +34124,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-non-reasoning-beta": {
@@ -44914,14 +34141,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-reasoning": {
@@ -44937,14 +34158,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.20-reasoning-beta": {
@@ -44960,14 +34175,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.3": {
@@ -44984,21 +34193,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.5": {
@@ -45015,21 +34214,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-4.6": {
@@ -45047,20 +34236,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-build-0.1": {
@@ -45077,13 +34257,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-imagine-image": {
@@ -45099,12 +34274,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "spacexai/grok-imagine-image-2.0": {
@@ -45120,12 +34291,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "image"
-            ]
+            "input": ["text"],
+            "output": ["image"]
           }
         },
         "spacexai/grok-imagine-video": {
@@ -45141,12 +34308,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "spacexai/grok-imagine-video-1.5": {
@@ -45162,12 +34325,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text"],
+            "output": ["video"]
           }
         },
         "spacexai/grok-stt": {
@@ -45183,12 +34342,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["audio"],
+            "output": ["text"]
           }
         },
         "spacexai/grok-tts": {
@@ -45204,12 +34359,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "spacexai/grok-voice-think-fast-1.0": {
@@ -45225,14 +34376,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "spacexai/grok-voice-think-fast-2.0": {
@@ -45248,14 +34393,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text",
-              "audio"
-            ]
+            "input": ["text", "audio"],
+            "output": ["text", "audio"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -45272,20 +34411,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -45303,20 +34433,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-lite": {
@@ -45332,12 +34453,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-plus": {
@@ -45353,12 +34470,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy-mt2-pro": {
@@ -45374,12 +34487,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy3": {
@@ -45395,19 +34504,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "tencent/hy4-preview": {
@@ -45423,18 +34524,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "high"
-            ]
+            "efforts": ["none", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling": {
@@ -45450,25 +34544,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "thinkingmachines/inkling-small": {
@@ -45484,25 +34564,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "voyage/rerank-2.5": {
@@ -45518,12 +34584,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/rerank-2.5-lite": {
@@ -45539,12 +34601,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3-large": {
@@ -45560,12 +34618,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3.5": {
@@ -45581,12 +34635,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-3.5-lite": {
@@ -45602,12 +34652,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4": {
@@ -45623,12 +34669,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4-large": {
@@ -45644,12 +34686,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-4-lite": {
@@ -45665,12 +34703,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-code-2": {
@@ -45686,12 +34720,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-code-3": {
@@ -45707,12 +34737,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-finance-2": {
@@ -45728,12 +34754,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "voyage/voyage-law-2": {
@@ -45749,12 +34771,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -45774,13 +34792,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -45800,12 +34813,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5": {
@@ -45825,12 +34834,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5-air": {
@@ -45850,12 +34855,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.5v": {
@@ -45875,13 +34876,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.6": {
@@ -45901,12 +34897,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7": {
@@ -45926,12 +34918,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7-flash": {
@@ -45951,12 +34939,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-4.7-flashx": {
@@ -45976,12 +34960,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5": {
@@ -46000,12 +34980,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5-turbo": {
@@ -46025,12 +35001,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.1": {
@@ -46050,12 +35022,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.2": {
@@ -46072,19 +35040,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.2-fast": {
@@ -46101,19 +35062,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "xhigh"
-            ],
+            "efforts": ["high", "xhigh"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.3": {
@@ -46130,19 +35084,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.3-fast": {
@@ -46159,19 +35105,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "zai/glm-5.3-flash": {
@@ -46188,20 +35126,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "zai/glm-5v-turbo": {
@@ -46220,14 +35149,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -46246,14 +35169,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.20-0309-reasoning": {
@@ -46270,14 +35187,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.20-multi-agent-0309": {
@@ -46294,22 +35205,11 @@
             "functionCalling": false
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.3": {
@@ -46326,22 +35226,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.5": {
@@ -46358,21 +35247,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-4.6": {
@@ -46390,22 +35269,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["low", "medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-build-0.1": {
@@ -46422,14 +35290,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "grok-imagine-image": {
@@ -46445,15 +35307,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "pdf"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image", "pdf"]
           }
         },
         "grok-imagine-image-2.0": {
@@ -46469,15 +35324,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "pdf"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image", "pdf"]
           }
         },
         "grok-imagine-image-quality": {
@@ -46493,15 +35341,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "image",
-              "pdf"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["image", "pdf"]
           }
         },
         "grok-imagine-video": {
@@ -46517,15 +35358,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["video"]
           }
         },
         "grok-imagine-video-1.5": {
@@ -46541,15 +35375,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "video"
-            ]
+            "input": ["text", "image", "audio", "pdf"],
+            "output": ["video"]
           }
         }
       },
@@ -46571,12 +35398,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-omni": {
@@ -46596,16 +35419,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "mimo-v2-pro": {
@@ -46625,12 +35440,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5": {
@@ -46650,15 +35461,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46678,12 +35482,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro-ultraspeed": {
@@ -46703,12 +35503,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -46731,12 +35527,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -46753,12 +35545,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -46779,15 +35567,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46808,12 +35589,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -46830,12 +35607,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -46852,12 +35625,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -46874,12 +35643,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -46902,12 +35667,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -46924,12 +35685,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -46950,15 +35707,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -46979,12 +35729,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -47001,12 +35747,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -47023,12 +35765,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -47045,12 +35783,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -47073,12 +35807,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2-tts": {
@@ -47095,12 +35825,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5": {
@@ -47121,15 +35847,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-pro": {
@@ -47150,12 +35869,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "mimo-v2.5-tts": {
@@ -47172,12 +35887,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voiceclone": {
@@ -47194,12 +35905,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         },
         "mimo-v2.5-tts-voicedesign": {
@@ -47216,12 +35923,8 @@
             "functionCalling": false
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "audio"
-            ]
+            "input": ["text"],
+            "output": ["audio"]
           }
         }
       },
@@ -47243,12 +35946,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5-air": {
@@ -47268,12 +35967,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5-flash": {
@@ -47294,12 +35989,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.5v": {
@@ -47319,14 +36010,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "glm-4.6": {
@@ -47346,12 +36031,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.6v": {
@@ -47371,14 +36052,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "glm-4.7": {
@@ -47398,12 +36073,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-flash": {
@@ -47424,12 +36095,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-4.7-flashx": {
@@ -47449,12 +36116,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5": {
@@ -47473,12 +36136,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-turbo": {
@@ -47498,12 +36157,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.1": {
@@ -47523,12 +36178,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -47545,18 +36196,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -47573,19 +36217,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -47602,22 +36238,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-5v-turbo": {
@@ -47636,15 +36261,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         }
       },
@@ -47667,12 +36285,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5-turbo": {
@@ -47693,12 +36307,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2": {
@@ -47716,18 +36326,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.2-highspeed": {
@@ -47745,18 +36348,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3": {
@@ -47774,19 +36370,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "glm-5.3-flash": {
@@ -47804,22 +36392,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "glm-5.3-highspeed": {
@@ -47837,19 +36414,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "high",
-              "max"
-            ]
+            "efforts": ["low", "high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         }
       },
@@ -47868,13 +36437,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-3.7-sonnet": {
@@ -47891,21 +36455,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-fable-5": {
@@ -47922,21 +36476,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-haiku-4.5": {
@@ -47953,13 +36497,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4": {
@@ -47976,21 +36515,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.1": {
@@ -48007,21 +36536,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.5": {
@@ -48038,21 +36557,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.6": {
@@ -48069,20 +36578,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.7": {
@@ -48099,21 +36599,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-opus-4.8": {
@@ -48130,21 +36620,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -48161,21 +36641,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.5": {
@@ -48192,21 +36662,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-4.6": {
@@ -48223,20 +36683,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5": {
@@ -48253,21 +36704,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "anthropic/claude-sonnet-5-free": {
@@ -48285,21 +36726,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "baidu/ernie-5.0-thinking-preview": {
@@ -48316,14 +36747,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-chat": {
@@ -48340,12 +36765,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2": {
@@ -48365,12 +36786,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v3.2-exp": {
@@ -48390,12 +36807,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-flash": {
@@ -48413,20 +36826,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "deepseek/deepseek-v4-pro": {
@@ -48444,20 +36849,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "efforts": ["low", "medium", "high"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash": {
@@ -48474,22 +36871,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-flash-lite": {
@@ -48506,15 +36892,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-2.5-pro": {
@@ -48531,23 +36910,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text", "audio", "video"],
+            "output": ["text"]
           }
         },
         "google/gemini-3-flash-preview": {
@@ -48564,22 +36931,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite": {
@@ -48597,23 +36953,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-flash-lite-preview": {
@@ -48629,15 +36973,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.1-pro-preview": {
@@ -48654,23 +36991,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf", "audio", "video"],
+            "output": ["text"]
           }
         },
         "google/gemini-3.5-flash": {
@@ -48688,23 +37013,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "audio", "pdf"],
+            "output": ["text"]
           }
         },
         "inclusionai/ling-1t": {
@@ -48721,12 +37034,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ring-1t": {
@@ -48743,12 +37052,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "inclusionai/ring-2.6-1t": {
@@ -48765,12 +37070,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "kuaishou/kat-coder-pro-v2": {
@@ -48786,12 +37087,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2": {
@@ -48808,12 +37105,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.1": {
@@ -48830,12 +37123,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5": {
@@ -48852,12 +37141,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.5-lightning": {
@@ -48874,12 +37159,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7": {
@@ -48896,12 +37177,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m2.7-highspeed": {
@@ -48918,12 +37195,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "minimax/minimax-m3": {
@@ -48942,14 +37215,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-0905": {
@@ -48966,12 +37233,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking": {
@@ -48988,12 +37251,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2-thinking-turbo": {
@@ -49010,12 +37269,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.5": {
@@ -49035,14 +37290,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.6": {
@@ -49062,14 +37311,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code": {
@@ -49087,14 +37330,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k2.7-code-free": {
@@ -49113,14 +37350,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3": {
@@ -49137,20 +37368,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ],
+            "efforts": ["max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "moonshotai/kimi-k3-free": {
@@ -49168,20 +37391,12 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "max"
-            ],
+            "efforts": ["max"],
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5": {
@@ -49198,21 +37413,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5-codex": {
@@ -49229,20 +37434,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1": {
@@ -49259,21 +37455,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-chat": {
@@ -49290,14 +37476,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "pdf",
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["pdf", "image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex": {
@@ -49314,20 +37494,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.1-codex-mini": {
@@ -49344,20 +37515,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2": {
@@ -49374,21 +37536,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "image",
-              "text",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-codex": {
@@ -49405,21 +37557,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.2-pro": {
@@ -49436,21 +37578,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-chat": {
@@ -49467,12 +37599,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.3-codex": {
@@ -49489,19 +37617,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4": {
@@ -49518,20 +37638,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-mini": {
@@ -49548,12 +37659,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-nano": {
@@ -49570,12 +37677,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.4-pro": {
@@ -49592,20 +37695,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5": {
@@ -49624,21 +37718,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-instant": {
@@ -49657,21 +37741,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.5-pro": {
@@ -49690,21 +37764,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "medium",
-              "high",
-              "xhigh"
-            ]
+            "efforts": ["medium", "high", "xhigh"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-luna": {
@@ -49723,24 +37787,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-sol": {
@@ -49759,24 +37810,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "openai/gpt-5.6-terra": {
@@ -49795,24 +37833,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ]
+            "efforts": ["none", "low", "medium", "high", "xhigh", "max"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-coder-plus": {
@@ -49829,12 +37854,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3-max": {
@@ -49851,12 +37872,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-flash": {
@@ -49873,13 +37890,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.5-plus": {
@@ -49896,20 +37908,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.6-plus": {
@@ -49928,12 +37931,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-max": {
@@ -49952,12 +37951,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "qwen/qwen3.7-plus": {
@@ -49977,14 +37972,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "sapiens-ai/agnes-1.5-lite": {
@@ -50000,13 +37989,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "sapiens-ai/agnes-1.5-pro": {
@@ -50022,12 +38006,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3": {
@@ -50044,13 +38024,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.5-flash": {
@@ -50067,12 +38042,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash": {
@@ -50090,21 +38061,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "stepfun/step-3.7-flash-free": {
@@ -50123,21 +38084,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "tencent/hy3-preview": {
@@ -50153,19 +38104,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "high"
-            ]
+            "efforts": ["none", "low", "high"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-1.8": {
@@ -50182,21 +38125,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-code": {
@@ -50213,12 +38146,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-lite": {
@@ -50235,21 +38164,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-mini": {
@@ -50266,21 +38185,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-2.0-pro": {
@@ -50297,21 +38206,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "volcengine/doubao-seed-code": {
@@ -50328,20 +38227,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4": {
@@ -50358,13 +38248,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "image",
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["image", "text"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4-fast": {
@@ -50384,13 +38269,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.1-fast": {
@@ -50410,13 +38290,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.1-fast-non-reasoning": {
@@ -50433,13 +38308,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.2-fast": {
@@ -50456,14 +38326,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.2-fast-non-reasoning": {
@@ -50480,14 +38344,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.3": {
@@ -50504,22 +38362,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["none", "low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-4.5": {
@@ -50536,21 +38383,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "efforts": ["low", "medium", "high"]
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-build-0.1": {
@@ -50567,14 +38404,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "pdf"],
+            "output": ["text"]
           }
         },
         "x-ai/grok-code-fast-1": {
@@ -50591,12 +38422,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-flash": {
@@ -50616,12 +38443,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-omni": {
@@ -50641,16 +38464,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video", "pdf"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2-pro": {
@@ -50670,12 +38485,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5": {
@@ -50695,15 +38506,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "audio",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "audio", "video"],
+            "output": ["text"]
           }
         },
         "xiaomi/mimo-v2.5-pro": {
@@ -50723,12 +38527,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5": {
@@ -50748,12 +38548,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.5-air": {
@@ -50773,12 +38569,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6": {
@@ -50795,12 +38587,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v": {
@@ -50817,14 +38605,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v-flash": {
@@ -50841,14 +38623,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.6v-flash-free": {
@@ -50866,14 +38642,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7": {
@@ -50890,12 +38660,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flash-free": {
@@ -50913,12 +38679,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-4.7-flashx": {
@@ -50935,12 +38697,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5": {
@@ -50957,12 +38715,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5-turbo": {
@@ -50979,12 +38733,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.1": {
@@ -51004,12 +38754,8 @@
             "toggle": true
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2": {
@@ -51026,18 +38772,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5.2-free": {
@@ -51055,18 +38794,11 @@
             "functionCalling": true
           },
           "thinkingOptions": {
-            "efforts": [
-              "high",
-              "max"
-            ]
+            "efforts": ["high", "max"]
           },
           "modalities": {
-            "input": [
-              "text"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text"],
+            "output": ["text"]
           }
         },
         "z-ai/glm-5v-turbo": {
@@ -51082,15 +38814,8 @@
             "functionCalling": true
           },
           "modalities": {
-            "input": [
-              "text",
-              "image",
-              "video",
-              "pdf"
-            ],
-            "output": [
-              "text"
-            ]
+            "input": ["text", "image", "video", "pdf"],
+            "output": ["text"]
           }
         }
       }


### PR DESCRIPTION
## Summary

Bundled `scripts/model-metadata/models-dev-api.snapshot.json` was still the 2026-09-01 retrieval. `opencode-go/deepseek-v4.1-flash` was missing, so the composer hid the thinking-level selector even though upstream models.dev declares `low` / `high` / `max`.

Refreshed the snapshot from models.dev (`retrievedAt` 2026-09-12). `projection.metadata.opencode-go.deepseek-v4.1-flash.thinkingOptions.efforts` is now `["low","high","max"]`.

Note: the scheduled Model metadata upkeep run on 2026-09-07 regenerated a newer snapshot and pushed `automation/model-metadata-refresh`, but `gh pr create` failed with `GitHub Actions is not permitted to create or approve pull requests`, so that refresh never landed. This PR is the human-path refresh until that org setting / token path is fixed.

Fixes #5231

## Verification

```sh
npm run refresh:model-metadata -- --accept-upstream-removals
npm run check:model-metadata
node --test scripts/sync-model-metadata.test.mjs
node --test scripts/model-metadata-upkeep-workflow-policy.test.mjs
```

All of the above passed locally.