### PR TITLE
revert(ci): stop triggering validation on PR edits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,17 +61,14 @@ github:
         required_approving_review_count: 1
       required_status_checks:
         strict: false
-        # test is the single required-check authority in
-        # .github/workflows/ci.yml. It runs for every new or updated pull request
-        # targeting main, including a pull request retargeted there. Title and
-        # body edits also run real validation in an isolated concurrency group;
-        # a newer skipped run can hide an earlier successful required check.
-        # The job runs install-free contract checks before installing the
-        # toolchain only for the validation its own
-        # planning step selects, so a documentation-only change still reports
-        # without paying for a build. Renaming the required job, adding a paths
-        # filter that stops ci.yml from running, or splitting this authority back
-        # across jobs can leave the check unreported and freeze pull requests.
+        # test is the single unconditional job in .github/workflows/ci.yml. It
+        # runs the install-free contract checks on every change and installs the
+        # toolchain only for the validation its own planning step selects, so a
+        # documentation-only change still reports without paying for a build.
+        # Renaming the job there, adding a paths filter that stops ci.yml from
+        # running, or splitting the work back across jobs so this context comes
+        # from an aggregator that can be skipped, freezes every pull request:
+        # the check never reports and no committer can override it.
         # A required context must report on every pull request, so a lane
         # behind a paths filter cannot be listed here: the filter would keep
         # the workflow from starting and the check would stay pending forever.

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,10 +63,11 @@ github:
         strict: false
         # test is the single required-check authority in
         # .github/workflows/ci.yml. It runs for every new or updated pull request
-        # targeting main, including a pull request retargeted there. Title- and
-        # body-only edits create a differently named skipped job, so they neither
-        # cancel nor satisfy this context. The job runs install-free contract
-        # checks before installing the toolchain only for the validation its own
+        # targeting main, including a pull request retargeted there. Title and
+        # body edits also run real validation in an isolated concurrency group;
+        # a newer skipped run can hide an earlier successful required check.
+        # The job runs install-free contract checks before installing the
+        # toolchain only for the validation its own
         # planning step selects, so a documentation-only change still reports
         # without paying for a build. Renaming the required job, adding a paths
         # filter that stops ci.yml from running, or splitting this authority back

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
   workflow_dispatch:
 
 concurrency:
-  # Title and body edits also run real validation: a newer skipped run can
-  # hide a successful required check. Keep edits from cancelling existing tests.
-  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.event.action == 'edited' && github.event.changes.base.ref.from == '' && format('-metadata-{0}', github.run_id) || '' }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # `edited` also covers title and body changes. Isolate those no-op runs so
-  # they cannot cancel the check for the current pull request revision.
-  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.event.action == 'edited' && github.event.changes.base.ref.from == '' && format('-ignored-{0}', github.run_id) || '' }}
+  # Title and body edits also run real validation: a newer skipped run can
+  # hide a successful required check. Keep edits from cancelling existing tests.
+  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.event.action == 'edited' && github.event.changes.base.ref.from == '' && format('-metadata-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -45,10 +45,6 @@ jobs:
   # Renaming it would leave that check unreported on every open pull request
   # until the rename merged, and nothing could merge while it was unreported.
   test:
-    # A base-ref edit keeps the protected `CI / test` name. Other edits create
-    # only a differently named skipped check, so they cannot satisfy it.
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base.ref.from == '' && 'ignored-edit' || 'test' }}
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base.ref.from != '' }}
     # Pinned, not `ubuntu-latest`. The two resolve to the same image, but only
     # the alias makes this required context wait at the tail, and the steps
     # below already assume this image. `ci-workflow-policy.test.mjs` holds the

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -56,19 +56,19 @@ test('GitHub output matches the selections consumed by CI', () => {
   assert.deepEqual(outputKeys, consumedKeys);
 });
 
-test('one job remains the only required-check authority', () => {
+test('one unconditional job carries the required context on every CI run', () => {
   const workflow = readWorkflow('ci.yml');
 
   // `.asf.yaml` requires `test`. A paths filter would stop the workflow and
   // leave that check pending forever, and a second job would create another
-  // authority. Metadata-only edits may skip this job under a different name;
-  // the retarget contract below proves that exception cannot impersonate it.
+  // authority. Every triggered run must actually validate the required context.
   assert.doesNotMatch(triggerBlock('ci.yml'), /\bpaths(-ignore)?:/u);
 
   const jobsBlock = workflow.slice(workflow.indexOf('\njobs:'));
   const jobs = [...jobsBlock.matchAll(/^ {2}([a-z0-9_-]+):$/gmu)].map((match) => match[1]);
   assert.deepEqual(jobs, ['test']);
   assert.doesNotMatch(jobsBlock, /^ {4}needs:/mu);
+  assert.doesNotMatch(jobsBlock, /^ {4}(?:if|name):/mu);
 });
 
 test('comparison precedes planning and every later gate uses plan outputs', () => {
@@ -116,23 +116,15 @@ test('every core diff gate consumes the shared comparison without resolving anot
   assert.match(workflow, /HEAD_SHA: \$\{\{ steps\.comparison\.outputs\.head \}\}/u);
 });
 
-test('core CI runs on base retargets without letting metadata edits replace the required check', () => {
+test('core CI includes retargets and isolates metadata runs from existing tests', () => {
   const workflow = readWorkflow('ci.yml');
 
   assert.match(workflow, /types: \[opened, synchronize, reopened, edited\]/u);
   assert.match(
     workflow,
-    /group: ci-\$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}\$\{\{ github\.event\.action == 'edited' && github\.event\.changes\.base\.ref\.from == '' && format\('-ignored-\{0\}', github\.run_id\) \|\| '' \}\}/u,
+    /group: ci-\$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}\$\{\{ github\.event\.action == 'edited' && github\.event\.changes\.base\.ref\.from == '' && format\('-metadata-\{0\}', github\.run_id\) \|\| '' \}\}/u,
   );
   assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
-  assert.match(
-    workflow,
-    /name: \$\{\{ github\.event_name == 'pull_request' && github\.event\.action == 'edited' && github\.event\.changes\.base\.ref\.from == '' && 'ignored-edit' \|\| 'test' \}\}/u,
-  );
-  assert.match(
-    workflow,
-    /if: \$\{\{ github\.event_name != 'pull_request' \|\| github\.event\.action != 'edited' \|\| github\.event\.changes\.base\.ref\.from != '' \}\}/u,
-  );
 });
 
 test('core CI uses the Windows inventory package-script authority', () => {

--- a/scripts/ci-workflow-policy.test.mjs
+++ b/scripts/ci-workflow-policy.test.mjs
@@ -56,19 +56,19 @@ test('GitHub output matches the selections consumed by CI', () => {
   assert.deepEqual(outputKeys, consumedKeys);
 });
 
-test('one unconditional job carries the required context on every CI run', () => {
+test('one unconditional job carries the required context on every pull request', () => {
   const workflow = readWorkflow('ci.yml');
 
   // `.asf.yaml` requires `test`. A paths filter would stop the workflow and
-  // leave that check pending forever, and a second job would create another
-  // authority. Every triggered run must actually validate the required context.
+  // leave that check pending forever, and a second job would make the same
+  // pull request queue for a scarce runner twice to reach one verdict.
   assert.doesNotMatch(triggerBlock('ci.yml'), /\bpaths(-ignore)?:/u);
 
   const jobsBlock = workflow.slice(workflow.indexOf('\njobs:'));
   const jobs = [...jobsBlock.matchAll(/^ {2}([a-z0-9_-]+):$/gmu)].map((match) => match[1]);
   assert.deepEqual(jobs, ['test']);
   assert.doesNotMatch(jobsBlock, /^ {4}needs:/mu);
-  assert.doesNotMatch(jobsBlock, /^ {4}(?:if|name):/mu);
+  assert.doesNotMatch(jobsBlock, /^ {4}if:/mu);
 });
 
 test('comparison precedes planning and every later gate uses plan outputs', () => {
@@ -114,17 +114,6 @@ test('every core diff gate consumes the shared comparison without resolving anot
     );
   }
   assert.match(workflow, /HEAD_SHA: \$\{\{ steps\.comparison\.outputs\.head \}\}/u);
-});
-
-test('core CI includes retargets and isolates metadata runs from existing tests', () => {
-  const workflow = readWorkflow('ci.yml');
-
-  assert.match(workflow, /types: \[opened, synchronize, reopened, edited\]/u);
-  assert.match(
-    workflow,
-    /group: ci-\$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}\$\{\{ github\.event\.action == 'edited' && github\.event\.changes\.base\.ref\.from == '' && format\('-metadata-\{0\}', github\.run_id\) \|\| '' \}\}/u,
-  );
-  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u);
 });
 
 test('core CI uses the Windows inventory package-script authority', () => {


### PR DESCRIPTION
## Summary

Revert #4186 (`83aa12a29c57e82bfe807e0913a35a90881cf6d0`) in full. Its `edited` trigger created a newer skipped CI run after a title/body edit, hiding an earlier successful `test` from branch protection and leaving PR #5225 blocked with `Required status check "test" is expected`.

Restore the default `pull_request` activities: `opened`, `synchronize`, and `reopened`. Title, body, and base-branch edits no longer trigger CI. Remove the metadata concurrency routing, dynamic job name, conditional job skip, and their obsolete policy assertions. The required `test` context and validation implementation stay unchanged.

**This intentionally restores the limitation described in #4181:** retargeting a PR to `main` without changing its head does not start CI. Push a new commit or reopen the PR to validate the new merge base. This rollback keeps metadata edits out of CI instead of adding a separate retarget scheduler.

Refs #4181, #4186, #5225.

## Verification

- 80 tests passed: `node --test --test-concurrency=1 scripts/ci-workflow-policy.test.mjs scripts/ci-test-plan.test.mjs`.
- `actionlint .github/workflows/ci.yml`, `npm run format`, `npm run lint`, and `git diff --check` passed.
- The original failure was independently reproduced in an isolated GitHub fixture with enforced required checks: a successful `test` produced CLEAN; a body-only edit produced a skipped run and BLOCKED despite the old success remaining in the API ([fixture PR](https://github.com/Astro-Han/maka-agent/pull/2), [skipped run](https://github.com/Astro-Han/maka-agent/actions/runs/34709709399)). Fixture branches and protection were removed.
- Application build/typecheck and the full Maka suite were not run locally for this workflow-only revert.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the failure, ran isolated GitHub experiments, and authored the rollback and verification. Commits include `Generated-by: Codex`.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
