### PR TITLE
perf(core): count diff lines without materializing display rows

### DIFF
--- a/packages/core/scripts/benchmark-unified-diff.mjs
+++ b/packages/core/scripts/benchmark-unified-diff.mjs
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Node >=22.19; no build or generated fixtures needed.
+// node --expose-gc packages/core/scripts/benchmark-unified-diff.mjs [baseline-ref]
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { cpus, release } from 'node:os';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+assert.equal(typeof global.gc, 'function', 'Run with node --expose-gc');
+const root = fileURLToPath(new URL('../../../', import.meta.url));
+const sourcePath = 'packages/core/src/unified-diff.ts';
+const baselineRef = process.argv[2] ?? 'd2e1be5db93101ffcc0fb6a107a0d51764ace28b';
+const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trimEnd();
+const baselineCommit = git('rev-parse', '--verify', `${baselineRef}^{commit}`);
+const baselineSource = git('show', `${baselineCommit}:${sourcePath}`);
+const candidateSource = readFileSync(new URL('../src/unified-diff.ts', import.meta.url), 'utf8');
+const load = (source) =>
+  import(
+    `data:text/javascript;base64,${Buffer.from(stripTypeScriptTypes(source)).toString('base64')}`
+  );
+const baseline = await load(baselineSource);
+const candidate = await load(candidateSource);
+const implementations = { baseline, candidate };
+const samples = 21;
+const warmupBatches = 8;
+const memorySamples = 9;
+let checksum = 0;
+
+const removed = '-old content 0123456789abcdefghijklmnopqrstuvwxyz\n';
+const added = '+new content 0123456789abcdefghijklmnopqrstuvwxyz\n';
+const context = ' unchanged content 0123456789abcdefghijklmnopqrst\n';
+
+function replacement(bodyLines, linePair = [removed, added]) {
+  const count = bodyLines / 2;
+  return {
+    name: `replacement-${bodyLines}`,
+    bodyLines,
+    diff:
+      `--- a/file\n+++ b/file\n@@ -1,${count} +1,${count} @@\n` +
+      linePair[0].repeat(count) +
+      linePair[1].repeat(count),
+    expected: { additions: count, deletions: count },
+  };
+}
+
+function manyHunks() {
+  const parts = [];
+  for (let file = 0; file < 100; file += 1) {
+    parts.push(
+      `diff --git a/file${file} b/file${file}\nindex 111..222\n--- a/file${file}\n+++ b/file${file}\n`,
+    );
+    for (let hunk = 0; hunk < 10; hunk += 1) {
+      const start = 1 + hunk * 100;
+      parts.push(`@@ -${start},50 +${start},50 @@\n`, removed.repeat(50), added.repeat(50));
+    }
+  }
+  return {
+    name: '100-files-1000-hunks',
+    bodyLines: 100000,
+    diff: parts.join(''),
+    expected: { additions: 50000, deletions: 50000 },
+  };
+}
+
+const fixtures = [
+  replacement(400),
+  replacement(10000),
+  replacement(100000),
+  replacement(500000),
+  {
+    name: 'context-heavy-100000',
+    bodyLines: 100000,
+    diff: '@@ -1,99000 +1,99000 @@\n' + (context.repeat(98) + removed + added).repeat(1000),
+    expected: { additions: 1000, deletions: 1000 },
+  },
+  manyHunks(),
+  {
+    ...replacement(200, [`-${'a'.repeat(32768)}\n`, `+${'b'.repeat(32768)}\n`]),
+    name: 'long-lines-200',
+  },
+];
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function consume(result) {
+  checksum += Array.isArray(result) ? result.length : result.additions + result.deletions;
+}
+
+function timeBatch(fn, diff, iterations) {
+  const start = performance.now();
+  for (let index = 0; index < iterations; index += 1) consume(fn(diff));
+  return (performance.now() - start) / iterations;
+}
+
+function heapDelta(fn, diff) {
+  global.gc();
+  const before = process.memoryUsage().heapUsed;
+  const result = fn(diff);
+  const delta = process.memoryUsage().heapUsed - before;
+  consume(result);
+  return delta;
+}
+
+// An untimed allocation-shape probe catches the original regression without
+// relying on noisy timing thresholds. Restore both hooks even on failure.
+function countAllocations(fn, diff) {
+  const originalPush = Array.prototype.push;
+  const originalSplit = String.prototype.split;
+  let displayRows = 0;
+  let fullLineSplits = 0;
+  let result;
+  try {
+    Array.prototype.push = function (...items) {
+      for (const item of items) {
+        if (item && typeof item === 'object' && 'kind' in item && 'text' in item) displayRows += 1;
+      }
+      return originalPush.apply(this, items);
+    };
+    String.prototype.split = function (...args) {
+      if (this === diff && args[0] === '\n') fullLineSplits += 1;
+      return originalSplit.apply(this, args);
+    };
+    result = fn(diff);
+  } finally {
+    Array.prototype.push = originalPush;
+    String.prototype.split = originalSplit;
+  }
+  return { displayRows, fullLineSplits, result };
+}
+
+const results = [];
+for (const fixture of fixtures) {
+  const { name, bodyLines, diff, expected } = fixture;
+  // Flatten generated ropes and verify before measuring; exclude fixture setup.
+  const inputBytes = Buffer.byteLength(diff);
+  for (const implementation of Object.values(implementations)) {
+    assert.deepEqual(implementation.countDiffLineStats(diff), expected, name);
+  }
+  assert.deepEqual(candidate.parseUnifiedDiffRows(diff), baseline.parseUnifiedDiffRows(diff), name);
+
+  const measurements = {};
+  // Bound each batch by both body lines and bytes, including the long-line case.
+  const iterations = Math.max(
+    1,
+    Math.min(250, Math.floor(100000 / bodyLines), Math.floor((8 * 1024 * 1024) / inputBytes)),
+  );
+  for (const operation of ['countDiffLineStats', 'parseUnifiedDiffRows']) {
+    for (let warmup = 0; warmup < warmupBatches; warmup += 1) {
+      for (const implementation of Object.values(implementations)) {
+        timeBatch(implementation[operation], diff, iterations);
+      }
+    }
+    const elapsed = { baseline: [], candidate: [] };
+    const heap = { baseline: [], candidate: [] };
+    for (let sample = 0; sample < samples; sample += 1) {
+      const order = sample % 2 === 0 ? ['baseline', 'candidate'] : ['candidate', 'baseline'];
+      for (const version of order) {
+        global.gc();
+        elapsed[version].push(timeBatch(implementations[version][operation], diff, iterations));
+      }
+    }
+    for (let sample = 0; sample < memorySamples; sample += 1) {
+      const order = sample % 2 === 0 ? ['baseline', 'candidate'] : ['candidate', 'baseline'];
+      for (const version of order) {
+        heap[version].push(heapDelta(implementations[version][operation], diff));
+      }
+    }
+    measurements[operation] = {
+      iterationsPerSample: iterations,
+      baselineMedianMs: median(elapsed.baseline),
+      candidateMedianMs: median(elapsed.candidate),
+      speedup: median(elapsed.baseline) / median(elapsed.candidate),
+      baselineHeapDeltaBytes: median(heap.baseline),
+      candidateHeapDeltaBytes: median(heap.candidate),
+      baselineSamplesMs: elapsed.baseline,
+      candidateSamplesMs: elapsed.candidate,
+    };
+  }
+  const allocations = Object.fromEntries(
+    Object.entries(implementations).map(([version, implementation]) => [
+      version,
+      countAllocations(implementation.countDiffLineStats, diff),
+    ]),
+  );
+  assert.deepEqual(allocations.candidate.result, expected);
+  assert.equal(allocations.candidate.displayRows, 0, `${name}: counting created display rows`);
+  assert.equal(allocations.candidate.fullLineSplits, 0, `${name}: counting split the full diff`);
+  results.push({ name, bodyLines, inputBytes, expected, measurements, allocations });
+}
+
+console.log(
+  JSON.stringify(
+    {
+      recordedAt: new Date().toISOString(),
+      environment: {
+        node: process.version,
+        v8: process.versions.v8,
+        platform: process.platform,
+        arch: process.arch,
+        osRelease: release(),
+        cpu: cpus()[0]?.model,
+      },
+      baselineCommit,
+      candidateSourceSha256: createHash('sha256').update(candidateSource).digest('hex'),
+      method: {
+        samples,
+        warmupBatches,
+        memorySamples,
+        order: 'alternating baseline/candidate; forced GC before each timed batch and heap sample',
+        heapMetric:
+          'heapUsed after one call minus heapUsed before it, after forced GC; not total allocations or exact peak',
+        scope: 'synthetic in-memory inputs; excludes Git, I/O, rendering and fixture construction',
+      },
+      results,
+      checksum,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/core/src/__tests__/unified-diff.test.ts
+++ b/packages/core/src/__tests__/unified-diff.test.ts
@@ -141,6 +141,33 @@ describe('parseUnifiedDiffRows', () => {
       { kind: 'meta', text: '-// old comment' },
     ]);
   });
+
+  test('preserves empty rows without creating a row for the terminating newline', () => {
+    assert.deepEqual(parseUnifiedDiffRows(''), [{ kind: 'meta', text: '' }]);
+    assert.deepEqual(parseUnifiedDiffRows('\n'), [{ kind: 'meta', text: '' }]);
+    assert.deepEqual(parseUnifiedDiffRows('\n\n'), [
+      { kind: 'meta', text: '' },
+      { kind: 'meta', text: '' },
+    ]);
+
+    const diff = '@@ -1,2 +1,2 @@\n\n-old\n+new';
+    const expected = [
+      { kind: 'hunk', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'ctx', text: '', oldLine: 1, newLine: 1 },
+      { kind: 'del', text: '-old', oldLine: 2 },
+      { kind: 'add', text: '+new', newLine: 2 },
+    ];
+    assert.deepEqual(parseUnifiedDiffRows(diff), expected);
+    assert.deepEqual(parseUnifiedDiffRows(`${diff}\n`), expected);
+  });
+
+  test('retains carriage returns in CRLF input', () => {
+    assert.deepEqual(parseUnifiedDiffRows('--- a/x\r\n+++ b/x\r\n@@ -1 +1 @@\r\n-a\r\n+b\r\n'), [
+      { kind: 'hunk', text: '@@ -1 +1 @@\r' },
+      { kind: 'del', text: '-a\r', oldLine: 1 },
+      { kind: 'add', text: '+b\r', newLine: 1 },
+    ]);
+  });
 });
 
 describe('countDiffLineStats', () => {
@@ -154,5 +181,88 @@ describe('countDiffLineStats', () => {
     const diff = ['--- /dev/null', '+++ b/new.md', '@@ -0,0 +1,2 @@', '+alpha', '+beta'].join('\n');
 
     assert.deepEqual(countDiffLineStats(diff), { additions: 2, deletions: 0 });
+  });
+
+  test('counts actual hunk content, including truncated and zero-count hunks', () => {
+    const cases = [
+      { diff: '', additions: 0, deletions: 0 },
+      { diff: '+foreign\n-old\n', additions: 0, deletions: 0 },
+      { diff: '@@ -1,0 +1,0 @@\n+outside\n', additions: 0, deletions: 0 },
+      { diff: '@@ -1,9 +1,9 @@\n-old\n+new\n', additions: 1, deletions: 1 },
+      { diff: '@@ -1,2 +0,0 @@\n-first\n-second', additions: 0, deletions: 2 },
+      { diff: '@@ -1 +1 @@\n--- comment\n+++i\n+outside', additions: 1, deletions: 1 },
+      {
+        diff: '@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file',
+        additions: 1,
+        deletions: 1,
+      },
+      { diff: '@@ -1,2 +1,2 @@\n\n-old\n+new\n', additions: 1, deletions: 1 },
+      { diff: '@@ -1 +1 @@\r\n-old\r\n+new\r\n', additions: 1, deletions: 1 },
+      {
+        diff: 'diff --git a/x b/x\nBinary files a/x and b/x differ\n',
+        additions: 0,
+        deletions: 0,
+      },
+    ];
+    for (const { diff, additions, deletions } of cases) {
+      assert.deepEqual(countDiffLineStats(diff), { additions, deletions }, diff);
+    }
+  });
+
+  test('matches independently generated rows and counts across 1,000 seeded multi-file diffs', () => {
+    let seed = 0xc083;
+    const random = (limit: number): number => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      return seed % limit;
+    };
+    const contents = ['', 'content', '-- comment', '++i', '@@ header-like', 'diff --git', '中文'];
+
+    for (let trial = 0; trial < 1000; trial += 1) {
+      const lines: string[] = [];
+      const expectedRows: ReturnType<typeof parseUnifiedDiffRows> = [];
+      let additions = 0;
+      let deletions = 0;
+      for (let file = 0, files = random(3) + 1; file < files; file += 1) {
+        const separator = `diff --git a/file${file} b/file${file}`;
+        lines.push(separator, 'index 1111111..2222222', `--- a/file${file}`, `+++ b/file${file}`);
+        expectedRows.push({ kind: 'meta', text: separator });
+        for (let hunk = 0, hunks = random(4) + 1; hunk < hunks; hunk += 1) {
+          const oldStart = random(1000) + 1;
+          const newStart = random(1000) + 1;
+          let oldLine = oldStart;
+          let newLine = newStart;
+          const body: ReturnType<typeof parseUnifiedDiffRows> = [];
+          for (let row = 0, rows = random(25) + 1; row < rows; row += 1) {
+            const text = contents[random(contents.length)];
+            const kind = random(3);
+            if (kind === 0) {
+              body.push({ kind: 'add', text: `+${text}`, newLine: newLine++ });
+              additions += 1;
+            } else if (kind === 1) {
+              body.push({ kind: 'del', text: `-${text}`, oldLine: oldLine++ });
+              deletions += 1;
+            } else {
+              body.push({ kind: 'ctx', text: ` ${text}`, oldLine: oldLine++, newLine: newLine++ });
+            }
+          }
+          const oldCount = oldLine - oldStart;
+          const newCount = newLine - newStart;
+          const oldRange =
+            oldCount === 1 ? `${oldStart}` : `${oldCount === 0 ? 0 : oldStart},${oldCount}`;
+          const newRange =
+            newCount === 1 ? `${newStart}` : `${newCount === 0 ? 0 : newStart},${newCount}`;
+          const header = `@@ -${oldRange} +${newRange} @@`;
+          lines.push(header, ...body.map((row) => row.text));
+          expectedRows.push({ kind: 'hunk', text: header }, ...body);
+        }
+      }
+      const diff = lines.join('\n') + (random(2) ? '\n' : '');
+      assert.deepEqual(parseUnifiedDiffRows(diff), expectedRows, `rows for trial ${trial}`);
+      assert.deepEqual(
+        countDiffLineStats(diff),
+        { additions, deletions },
+        `counts for trial ${trial}`,
+      );
+    }
   });
 });

--- a/packages/core/src/__tests__/unified-diff.test.ts
+++ b/packages/core/src/__tests__/unified-diff.test.ts
@@ -183,6 +183,40 @@ describe('countDiffLineStats', () => {
     assert.deepEqual(countDiffLineStats(diff), { additions: 2, deletions: 0 });
   });
 
+  test('counts without materializing display rows or splitting the full diff', () => {
+    const diff = '--- a/file\n+++ b/file\n@@ -1,2 +1,2 @@\n kept\n-old\n+new\n';
+    const originalPush = Array.prototype.push;
+    const originalSplit = String.prototype.split;
+    let displayRows = 0;
+    let fullLineSplits = 0;
+    let stats: ReturnType<typeof countDiffLineStats>;
+
+    // Probe only the synchronous call, restoring globals before assertions or
+    // test-runner work. This catches the original allocation regression without
+    // depending on machine-specific timing or heap thresholds.
+    try {
+      Array.prototype.push = function (this: unknown[], ...items: unknown[]): number {
+        for (const item of items) {
+          if (item && typeof item === 'object' && 'kind' in item && 'text' in item) {
+            displayRows += 1;
+          }
+        }
+        return Reflect.apply(originalPush, this, items);
+      };
+      String.prototype.split = function (this: string, ...args: unknown[]): string[] {
+        if (this === diff && args[0] === '\n') fullLineSplits += 1;
+        return Reflect.apply(originalSplit, this, args);
+      };
+      stats = countDiffLineStats(diff);
+    } finally {
+      Array.prototype.push = originalPush;
+      String.prototype.split = originalSplit;
+    }
+
+    assert.deepEqual(stats, { additions: 1, deletions: 1 });
+    assert.deepEqual({ displayRows, fullLineSplits }, { displayRows: 0, fullLineSplits: 0 });
+  });
+
   test('counts actual hunk content, including truncated and zero-count hunks', () => {
     const cases = [
       { diff: '', additions: 0, deletions: 0 },

--- a/packages/core/src/unified-diff.ts
+++ b/packages/core/src/unified-diff.ts
@@ -56,40 +56,63 @@ const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
  * structure — degrades to unnumbered meta rows.
  */
 export function parseUnifiedDiffRows(diff: string): UnifiedDiffRow[] {
-  const lines = diff.split('\n');
-  // A trailing newline terminates the diff rather than starting an empty row.
-  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
-
   const rows: UnifiedDiffRow[] = [];
+  scanUnifiedDiff(diff, rows);
+  return rows;
+}
+
+/** Green `+N` / red `-N` counts, without materializing display rows or body text. */
+export function countDiffLineStats(diff: string): { additions: number; deletions: number } {
+  return scanUnifiedDiff(diff);
+}
+
+/**
+ * One structural scan for both consumers. The optional output array keeps
+ * display objects and body substrings out of the count-only path.
+ */
+function scanUnifiedDiff(
+  diff: string,
+  rows?: UnifiedDiffRow[],
+): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
   let oldLine = 0;
   let newLine = 0;
   let remainingOld = 0;
   let remainingNew = 0;
   let inHunk = false;
+  let offset = 0;
 
-  for (const line of lines) {
+  // Visit an empty input once, but do not invent a row after a trailing newline.
+  do {
+    const start = offset;
+    const newline = diff.indexOf('\n', start);
+    const end = newline === -1 ? diff.length : newline;
+    offset = end + 1;
     if (inHunk && remainingOld + remainingNew > 0) {
-      const marker = line.charAt(0);
+      const marker = diff.charAt(start);
       if (marker === '\\') {
         // `\ No newline at end of file` annotates the previous row without
         // consuming a line on either side.
-        rows.push({ kind: 'meta', text: line });
+        rows?.push({ kind: 'meta', text: diff.slice(start, end) });
         continue;
       }
       if (marker === '-') {
-        rows.push({ kind: 'del', text: line, oldLine });
+        rows?.push({ kind: 'del', text: diff.slice(start, end), oldLine });
+        deletions += 1;
         oldLine += 1;
         remainingOld -= 1;
         continue;
       }
       if (marker === '+') {
-        rows.push({ kind: 'add', text: line, newLine });
+        rows?.push({ kind: 'add', text: diff.slice(start, end), newLine });
+        additions += 1;
         newLine += 1;
         remainingNew -= 1;
         continue;
       }
       // ' ' context, and the bare empty line some generators emit for one.
-      rows.push({ kind: 'ctx', text: line, oldLine, newLine });
+      rows?.push({ kind: 'ctx', text: diff.slice(start, end), oldLine, newLine });
       oldLine += 1;
       newLine += 1;
       remainingOld -= 1;
@@ -98,6 +121,7 @@ export function parseUnifiedDiffRows(diff: string): UnifiedDiffRow[] {
     }
     inHunk = false;
 
+    const line = diff.slice(start, end);
     const hunk = HUNK_HEADER.exec(line);
     if (hunk) {
       oldLine = Number(hunk[1]);
@@ -105,28 +129,17 @@ export function parseUnifiedDiffRows(diff: string): UnifiedDiffRow[] {
       remainingOld = hunk[2] === undefined ? 1 : Number(hunk[2]);
       remainingNew = hunk[4] === undefined ? 1 : Number(hunk[4]);
       inHunk = true;
-      rows.push({ kind: 'hunk', text: line });
+      rows?.push({ kind: 'hunk', text: line });
       continue;
     }
     if (line.startsWith('diff ')) {
-      rows.push({ kind: 'meta', text: line });
+      rows?.push({ kind: 'meta', text: line });
       continue;
     }
     if (line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ')) {
       continue;
     }
-    rows.push({ kind: 'meta', text: line });
-  }
-  return rows;
-}
-
-/** Green `+N` / red `-N` counts, from the structural parse. */
-export function countDiffLineStats(diff: string): { additions: number; deletions: number } {
-  let additions = 0;
-  let deletions = 0;
-  for (const row of parseUnifiedDiffRows(diff)) {
-    if (row.kind === 'add') additions += 1;
-    else if (row.kind === 'del') deletions += 1;
-  }
+    rows?.push({ kind: 'meta', text: line });
+  } while (offset < diff.length);
   return { additions, deletions };
 }


### PR DESCRIPTION
## Summary

Fixes #5242

`countDiffLineStats` previously built every display row and a complete split-line array just to return additions/deletions. Share one structural scanner with `parseUnifiedDiffRows`; counting now skips display objects and body substrings while preserving hunk semantics, row shapes, and public APIs.

Includes boundary tests, 1,000 seeded multi-file fixtures with independently generated expected rows/counts, and a reproducible benchmark. The 100,000-line replacement fixture counts 2.86× faster and creates zero display rows.

## Verification

- Passed: `npm run lint`, `npm run format:check`, `npm run build`, `npm run typecheck`.
- Passed: `npx --no-install knip --workspace apps/desktop` and `npx --no-install knip --workspace packages/ui`.
- Affected tests: 838 core tests; 137 Git review / CLI transcript / UI tool-activity tests; 16 runtime file-tool tests; one model-history replay test. **992 passed, 3 Windows-only cases skipped, 0 failed.** The initial submission included a full workspace build and downstream suite run; this test-only follow-up rebuilt core and reran all 838 core tests.
- An additional 10,000 seeded mixed/malformed inputs produced identical rows and counts against the baseline.
- The regular core suite now includes a deterministic allocation regression test: the baseline fails with four display-row pushes and one full-line split; the current implementation passes with both at zero. Prototype hooks wrap only the synchronous count call and are restored in `finally` before assertions. This guard runs in CI without timing or heap thresholds. The benchmark retains the same allocation assertions across all seven scenarios; the semantic tests also pass against the baseline to verify compatibility.
- Full cross-workspace test suite, Electron E2E, and Windows execution were not run locally.

### Benchmark

Apple M4 Pro, macOS arm64, Node v24.14.0 / V8 13.6.233.17-node.41. Baseline: `d2e1be5db93101ffcc0fb6a107a0d51764ace28b`. Eight warmup batches, 21 timing samples with alternating version order, forced GC before each batch; medians below are milliseconds per call. Fixture generation, Git/I/O and rendering are outside timing.

| Count scenario | Input MiB | Before ms | After ms | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 400 replacement lines | 0.019 | 0.0092 | 0.0038 | 2.39× |
| 10,000 replacement lines | 0.477 | 0.2422 | 0.0979 | 2.47× |
| 100,000 replacement lines | 4.768 | 2.7539 | 0.9617 | 2.86× |
| 500,000 replacement lines | 23.842 | 13.9292 | 4.6446 | 3.00× |
| 100,000 lines, 98% context | 4.768 | 2.9051 | 0.9448 | 3.07× |
| 100 files / 1,000 hunks / 100,000 lines | 4.796 | 2.9791 | 1.0385 | 2.87× |
| 200 lines, ~32 KiB each | 6.250 | 0.1295 | 0.1253 | 1.03× |

For 100,000 replacement lines, median per-call `heapUsed` delta dropped **11.021 MiB → 576 B**, and display objects **100,001 → 0**. The 1,000-hunk input dropped **11.339 MiB → 272,408 B** because header regex matches still allocate. Heap measurements use nine separate samples after forced GC; these are before/after deltas, **not total allocated bytes or exact peaks**. The 576 B result is near the measurement overhead.

Display parsing was also checked for identical output and no measured slowdown: the 100,000-line fixture changed **2.6189 → 1.9725 ms**. Long-line inputs show little speedup because text scanning dominates. The 500,000-line fixture is a core stress case exceeding the Git review input cap; these numbers do not imply equivalent end-to-end UI gains.

Reproduce:

```sh
node --expose-gc packages/core/scripts/benchmark-unified-diff.mjs d2e1be5db93101ffcc0fb6a107a0d51764ace28b
```

[Benchmark script](https://github.com/liuxiaocs7/maka/blob/perf/count-diff-without-display-rows/packages/core/scripts/benchmark-unified-diff.mjs).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with diagnosis, implementation, tests, benchmarking, and this submission. This automated submission was requested by @liuxiaocs7, the human contributor of record. Both commits include `Generated-by: Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
